### PR TITLE
fix: update-image-digest の正規表現で RE2 非対応の否定先読みを修正

### DIFF
--- a/cmd/update-image-digest/main.go
+++ b/cmd/update-image-digest/main.go
@@ -71,7 +71,7 @@ func updateManifests(images []string, digest string) error {
 
 			hasChanged = true
 			manifest = newManifest
-			log.Printf("updated %s with %s", path, newImageSpec)
+			log.Printf("updated %s with %s@sha256:%s", path, image, digest)
 		}
 		if !hasChanged {
 			return nil


### PR DESCRIPTION
## Summary
- `cmd/update-image-digest/main.go` で使用していた否定先読み `(?!...)` が Go の regexp (RE2) で非対応のため `MustCompile` が panic していた
- 否定文字クラス `([^...]|$)` + キャプチャグループによる代替手法に置き換え

## 関連
- https://github.com/SlashNephy/infrastructure/actions/runs/23707619726/job/69062047002

## Test plan
- [x] `go build ./cmd/update-image-digest/` でビルド成功を確認
- [x] 実際の引数で `go run` して panic しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)