### PR TITLE
fix: nebula backend の Pod 終了制御を分離する

### DIFF
--- a/k8s/apps/nebula/kustomization.yaml
+++ b/k8s/apps/nebula/kustomization.yaml
@@ -84,6 +84,7 @@ resources:
   - ./resources/deployment-instagram.yaml
   - ./resources/deployment-ml.yaml
   - ./resources/deployment-river-ui.yaml
+  - ./resources/deployment-worker.yaml
   - ./resources/deployment-xctid.yaml
   - ./resources/dns.yaml
   - ./resources/ingress.yaml

--- a/k8s/apps/nebula/resources/deployment-backend.yaml
+++ b/k8s/apps/nebula/resources/deployment-backend.yaml
@@ -29,7 +29,7 @@ spec:
               mountPath: /app/media
             - name: avatars
               mountPath: /app/avatars
-            - name: content
+            - name: media
               mountPath: /app/content
           livenessProbe:
             httpGet:
@@ -54,11 +54,8 @@ spec:
           hostPath:
             path: /mnt/local/nebula/avatars
             type: DirectoryOrCreate
-        - name: content
-          hostPath:
-            path: /mnt/pool/nebula_media
-            type: DirectoryOrCreate
       restartPolicy: Always
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-io-credentials
       securityContext:

--- a/k8s/apps/nebula/resources/deployment-worker.yaml
+++ b/k8s/apps/nebula/resources/deployment-worker.yaml
@@ -1,29 +1,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: backend
+  name: worker
 
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: backend
+      app: worker
   template:
     metadata:
       labels:
-        app: backend
+        app: worker
     spec:
       containers:
-        - name: server
-          image: ghcr.io/slashnephy/nebula-backend:main@sha256:4391163b722261762391e5b0a75a884d07aa41bdc5009d617c7ff52988010ea5
+        - name: worker
+          image: ghcr.io/slashnephy/nebula-worker:main@sha256:dde2c720b8d5a293640feaf958ff4f5302ab010ee942b380771d379296366177
           envFrom:
             - configMapRef:
                 name: backend-config
             - secretRef:
                 name: backend-secrets
-          ports:
-            - name: http
-              containerPort: 8080
           volumeMounts:
             - name: media
               mountPath: /app/media
@@ -31,14 +28,6 @@ spec:
               mountPath: /app/avatars
             - name: content
               mountPath: /app/content
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: http
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -64,4 +53,4 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90

--- a/k8s/apps/nebula/resources/deployment-worker.yaml
+++ b/k8s/apps/nebula/resources/deployment-worker.yaml
@@ -26,7 +26,7 @@ spec:
               mountPath: /app/media
             - name: avatars
               mountPath: /app/avatars
-            - name: content
+            - name: media
               mountPath: /app/content
           securityContext:
             allowPrivilegeEscalation: false
@@ -43,11 +43,8 @@ spec:
           hostPath:
             path: /mnt/local/nebula/avatars
             type: DirectoryOrCreate
-        - name: content
-          hostPath:
-            path: /mnt/pool/nebula_media
-            type: DirectoryOrCreate
       restartPolicy: Always
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-io-credentials
       securityContext:


### PR DESCRIPTION
## 概要
- nebula backend Deployment から worker コンテナを分離し、worker Deployment を追加しました
- backend server に readinessProbe を追加しました
- server / worker それぞれに `terminationGracePeriodSeconds` を明示しました

## 検証
- `MISE_TRUSTED_CONFIG_PATHS=/var/tmp/infrastructure-nebula-rollout-safety mise exec -- kustomize build --enable-helm k8s/apps/nebula >/tmp/nebula-kustomize-build.yaml`
- `MISE_TRUSTED_CONFIG_PATHS=/var/tmp/infrastructure-nebula-rollout-safety mise exec -- pnpm exec eslint .`
- `git diff --check`