### PR TITLE
update-image-digest ワークフローを直列実行にする

### DIFF
--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: update-image-digest
-  queue: max
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -6,7 +6,8 @@ on:
       - update-image-digest
 
 concurrency:
-  group: deploy-${{ join(github.event.client_payload.images, ',') }}
+  group: update-image-digest
+  queue: max
 
 permissions: {}
 


### PR DESCRIPTION
## 概要
- update-image-digest ワークフローの concurrency group を image 単位から workflow 全体に変更
- 同時 dispatch された更新を queue に積み、複数の自動マージが同時に master を更新しないように変更

## 確認
- pnpm exec eslint .github/workflows/update-image-digest.yml
- git diff --check