### PR TITLE
update-image-digest で Go を事前セットアップする

### DIFF
--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -20,8 +20,17 @@ jobs:
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: cmd/update-image-digest/go.mod
+          cache-dependency-path: cmd/update-image-digest/go.sum
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
       - name: Update Image Digest
-        run: go run ./cmd/update-image-digest -i ${{ join(github.event.client_payload.images, ',') }} -d ${{ github.event.client_payload.digest }}
+        run: |
+          GOWORK=off GOTOOLCHAIN=local go build -C cmd/update-image-digest -o "$RUNNER_TEMP/update-image-digest" .
+          "$RUNNER_TEMP/update-image-digest" -i ${{ join(github.event.client_payload.images, ',') }} -d ${{ github.event.client_payload.digest }}
 
       - name: Create Pull Request
         id: create-pull-request

--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -25,12 +25,14 @@ jobs:
         with:
           go-version-file: cmd/update-image-digest/go.mod
           cache-dependency-path: cmd/update-image-digest/go.sum
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Update Image Digest
         run: |
           GOWORK=off GOTOOLCHAIN=local go build -C cmd/update-image-digest -o "$RUNNER_TEMP/update-image-digest" .
-          "$RUNNER_TEMP/update-image-digest" -i ${{ join(github.event.client_payload.images, ',') }} -d ${{ github.event.client_payload.digest }}
+          "$RUNNER_TEMP/update-image-digest" -i "$IMAGES" -d "$DIGEST"
+        env:
+          IMAGES: ${{ join(github.event.client_payload.images, ',') }}
+          DIGEST: ${{ github.event.client_payload.digest }}
 
       - name: Create Pull Request
         id: create-pull-request


### PR DESCRIPTION
## 概要
- update-image-digest ワークフローに actions/setup-go を追加
- cmd/update-image-digest の go.mod / go.sum に絞って Go version と cache key を設定
- update-image-digest は GOWORK=off / GOTOOLCHAIN=local でビルドし、repository root から binary を実行するように変更

## 背景
Update Image Digest step で go run が毎回 Go toolchain と依存を取得しており、実行時間の支配的な要因になっていました。setup-go に寄せることで toolchain 解決と module/build cache を workflow step として扱えるようにします。

## 確認
- GOWORK=off GOTOOLCHAIN=local mise exec go -- go build -C cmd/update-image-digest -o /tmp/infrastructure-update-image-digest .
- /tmp/infrastructure-update-image-digest -i example.invalid/test:tag -d sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
- pnpm exec eslint .github/workflows/update-image-digest.yml
- git diff --check
- mise exec go -- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/update-image-digest.yml