### PR TITLE
fix: nebula の backend と worker を UID 1000 で実行

### DIFF
--- a/k8s/apps/nebula/resources/deployment-backend.yaml
+++ b/k8s/apps/nebula/resources/deployment-backend.yaml
@@ -67,6 +67,9 @@ spec:
       imagePullSecrets:
         - name: ghcr-io-credentials
       securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 30

--- a/k8s/apps/nebula/resources/deployment-worker.yaml
+++ b/k8s/apps/nebula/resources/deployment-worker.yaml
@@ -56,6 +56,9 @@ spec:
       imagePullSecrets:
         - name: ghcr-io-credentials
       securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 90


### PR DESCRIPTION
## 概要
- nebula backend の Pod securityContext に `runAsUser: 1000` / `runAsGroup: 1000` / `runAsNonRoot: true` を追加
- nebula worker も同様に UID/GID 1000 で実行するように変更
- `fsGroup` はホスト側ボリュームの所有権・グループ変更を避けるため設定しない

## 確認
- `MISE_TRUSTED_CONFIG_PATHS=/home/spica/ghq/github.com/SlashNephy/infrastructure mise exec -- kustomize build --enable-helm k8s/apps/nebula`
- `MISE_TRUSTED_CONFIG_PATHS=/home/spica/ghq/github.com/SlashNephy/infrastructure mise exec -- go run ./cmd/build-manifests` は `k8s/system/openclaw-operator` の Helm chart `ghcr.io/openclaw-rocks/charts/openclaw-operator:0.34.4` が not found で失敗。対象の `k8s/apps/nebula` は成功。