### PR TITLE
fix(ci): stale なイメージダイジェスト更新 PR の発生と滞留を止める

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # JST 09:00 every day
+  # debug-only での動作確認と、緊急時の手動回収のために手動実行を許可する
+  workflow_dispatch:
+    inputs:
+      debug-only:
+        description: Log what would be closed without actually closing
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  close-stale-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # delete-branch がブランチを消すのに要る
+      pull-requests: write
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          # 回収対象は update-image-digest.yml が automerge ラベルを付けた PR に限る。
+          # close-pr-label は「クローズ時に付与するラベル」であって絞り込みではないので使わない。
+          # Renovate は renovate ラベル、Dependabot は dependencies ラベルなので巻き込まれない。
+          any-of-pr-labels: automerge
+          # イメージダイジェスト更新 PR は 1 日も経てば新しいダイジェストに置き換わっている。
+          # 残っているのはマージに失敗したものだけなので、stale と判定したら猶予なく閉じる。
+          days-before-pr-stale: 1
+          days-before-pr-close: 0
+          # Issue は対象外
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          delete-branch: true
+          # schedule 実行では inputs が空になるため false に倒す
+          debug-only: ${{ inputs.debug-only || false }}

--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -19,6 +19,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          # repository_dispatch の github.sha は「イベント発生時の default branch 先頭」で固定される。
+          # ref を省略すると checkout はその SHA をそのまま掴むため、concurrency のキュー待ちの間に
+          # master が進んでいると古いコミットから分岐し、先にマージされた PR とコンフリクトする。
+          # ref を明示すると fetch 時にブランチ先端へ解決されるので、常に最新の master 上で更新できる。
+          # github.ref は repository_dispatch では default branch を指す。
+          ref: ${{ github.ref_name }}
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -48,6 +48,33 @@ jobs:
           branch-suffix: random
           title: update ${{ github.event.client_payload.images[0] }} 🔜 ${{ github.event.client_payload.digest }}
           body: https://github.com/${{ github.event.client_payload.github.repository }}/commit/${{ github.event.client_payload.github.sha }}
+          # stale.yaml がこのラベルで回収対象を絞り込む
+          labels: automerge
+
+      # 同一イメージのより新しい PR ができた時点で、古い PR のダイジェストは無意味になる。
+      # 下の gh pr merge はコンフリクトすると失敗して PR を残すため、その取りこぼしをここで回収する。
+      # マージが失敗しても実行されるよう、マージより前に置いている。
+      - name: Close Superseded Pull Requests
+        if: steps.create-pull-request.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          IMAGE: ${{ github.event.client_payload.images[0] }}
+          PR_NUMBER: ${{ steps.create-pull-request.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+
+          # 上の Create Pull Request が組み立てるタイトル・ブランチ名の規則で同一イメージの PR を絞り込む。
+          # 別イメージの PR を巻き込まないよう、ブランチ名とタイトルの両方で照合する。
+          gh pr list --state open --limit 100 --json number,title,headRefName \
+            --jq '.[]
+              | select(.headRefName | startswith("ci/update-image-digest-"))
+              | select(.title | startswith("update " + env.IMAGE + " 🔜"))
+              | select(.number != (env.PR_NUMBER | tonumber))
+              | .number' |
+          while read -r number; do
+            echo "Closing superseded pull request #${number}"
+            gh pr close "$number" --delete-branch --comment "Superseded by #${PR_NUMBER}"
+          done
 
       - run: gh pr merge --squash $PR_NUMBER
         if: steps.create-pull-request.outputs.pull-request-number


### PR DESCRIPTION
## 概要

イメージダイジェスト更新 PR がマージされずに残り続ける問題を直す。#9618 が 2026-07-17 から開きっぱなしになっていた。

原因は 2 つあり、どちらも別々に効いている。

1. **コンフリクトが起きる**（発生側）— checkout が古いコミットを掴んでいた
2. **残った PR が回収されない**（後始末側）— stale ワークフローが削除され、しかも削除前の設定も誤っていた

## 根本原因 1: checkout が古い master を掴む

`repository_dispatch` の `GITHUB_SHA` は「**イベント発生時**の default branch 先頭」で固定される（[公式ドキュメント](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#repository_dispatch)）。`actions/checkout` は `ref` 省略時にこの SHA をそのまま掴むため、`concurrency` のキュー待ちの間に master が進んでいると古いコミットから分岐する。

#9618 を生んだ run (`29564056369`) の実データ:

| | 値 |
|---|---|
| dispatch 発生時刻 | `2026-07-17T07:44:40Z` |
| その時点の master tip | `f84b14cb6`（**前日** 07-16T15:13Z のコミット） |
| run の `head_sha` | `f84b14cb660b1ef4dfc525e5db84840125f80f16` |
| PR #9618 のコミットの親 | `f84b14cb6` |
| checkout 実行時刻 | `2026-07-17T07:47:50Z` |
| その時点で master にあった #9613 | `07:45:38Z` に `nebula-worker` を更新済み |

同じ `k8s/apps/nebula/resources/deployment-worker.yaml` の同じ行を触るため衝突した。

`ref` を明示すると checkout が fetch 時にブランチ先端へ解決するため、実行時点の master 上で更新できる。`repository_dispatch` では `GITHUB_REF` が default branch を指すことを実 run の `head_branch: "master"` で確認済み。

## 根本原因 2: 回収機構が消えていた

`.github/workflows/stale.yaml` は 5dff4001a（2026-04-05）で削除され、46 分後の d9ae08eaa で絞り込みに使う `automerge` ラベルの付与も外れていた。

さらに、削除前の設定自体も意図どおり動いていなかった。

| 意図 | 実際 |
|---|---|
| `automerge` ラベル付き PR を対象 | `close-pr-label` は「**クローズ時に付与する**ラベル」であり絞り込みではないため、**全 PR**（Renovate 含む）が対象だった |
| 1 日でクローズ | `days-before-stale` のデフォルト 60 が効くため、実際は **61 日** |
| ブランチも削除 | `delete-branch` には `contents: write` が要るが `contents: read` だった |

つまり #9618 は、仮に `stale.yaml` が残っていてもまだクローズされていなかった。

## 変更内容

### `.github/workflows/update-image-digest.yml`

- `actions/checkout` に `ref: ${{ github.ref_name }}` を明示（根本原因 1）
- `labels: automerge` を復活（`stale.yml` の絞り込みに使う）
- `Close Superseded Pull Requests` ステップを追加。同一イメージのより新しい PR を作った時点で古い PR を閉じる。マージ失敗時も実行されるようマージより前に置いている

### `.github/workflows/stale.yml`

正しい設定で復活させた。ファイル名は他のワークフローに合わせて `.yml`。

- 絞り込みは `any-of-pr-labels: automerge`
- `days-before-pr-stale: 1` / `days-before-pr-close: 0`
- Issue は `days-before-issue-stale: -1` で対象外
- `contents: write`（`delete-branch` に必要）
- 検証用に `workflow_dispatch` + `debug-only` 入力

## 検証

| 項目 | 結果 |
|---|---|
| `pnpm eslint` | exit 0 |
| `actionlint` | 新規・変更箇所の指摘なし（既存の `queue: max` のみ。これは[有効な構文](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)で actionlint 1.7.12 が未対応なだけ） |
| YAML パース | OK |
| supersede の jq セレクタ（同一イメージ） | 実データに対して #9618 のみを選択 |
| supersede の jq セレクタ（自分自身の除外） | 空 |
| supersede の jq セレクタ（別イメージ） | 空 |
| `GITHUB_REF` / `GITHUB_SHA` の実値 | run `29564056369` の `head_branch: "master"` / `head_sha: f84b14cb6` で確認 |
| Renovate / Dependabot PR との干渉 | 現在の open PR 14 件を確認。`renovate` / `dependencies` ラベルのみで `automerge` を持つものは無し |

`gh pr merge` に `--auto` を付ける案は**採用しなかった**。auto-merge は「即座にマージできない PR」専用の機能で、このリポジトリは必須ステータスチェックが無いため大半の PR が拒否される。実際 `peter-evans/enable-pull-request-automerge` を使っていた時期（〜2026-04-05）は Automerge ステップが頻繁に失敗し、#8016 / #8018 / #8021 / #8022 / #8027 がマージされず放置されていた。

## 残作業

`workflow_dispatch` は default branch にワークフローが存在しないと発火できないため、`stale.yml` の実挙動はマージ後にしか確認できない。マージ後に以下を実施する。

1. #9618 に `automerge` ラベルを付与
2. `stale.yml` を `debug-only: true` で実行し、#9618 が対象として拾われることをログで確認
3. `debug-only: false` で実行し、実際にクローズとブランチ削除がされることを確認

そのため Draft にしている。

## 関連

- 別件で調査した PR 説明のコミット参照が壊れる問題は SlashNephy/nebula#1980 に切り出した

## 動物界における比擬

ハキリアリは切り取った葉を巣に運び、菌園に貼り付けて栽培する。ところがコロニーには常に *Escovopsis* という寄生菌が入り込む。放置すれば菌園は数日で崩壊するため、働きアリは絶えず菌園を歩き回り、感染した断片をくわえてゴミ捨て場へ運び出す。この掃除係を実験的に取り除くと、菌園はあっけなく壊死する。

このリポジトリで起きていたのは、まさにその掃除係の消失だった。`stale.yaml` を消したとき、菌園そのものは動いていたので誰も困らないように見えた。しかしマージに失敗した PR は寄生菌のように少しずつ溜まっていった。

もっとも、ハキリアリの防除はそれだけではない。彼らは体表に *Pseudonocardia* という放線菌を共生させ、抗生物質を分泌させて寄生菌の侵入そのものを抑えている。掃除は最後の砦であって、第一の守りは発生を許さないことにある。

今回の変更もこの二重構造をなぞっている。`ref` の明示が体表の放線菌にあたり、コンフリクトの発生自体を抑える。supersede クローズと `stale.yml` が働きアリの掃除にあたり、それでも入り込んだものを運び出す。片方だけでは巣は保たない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iphM8idUrQkVVAqkxc1wL
