### PR TITLE
feat: Mackerel へのログ送信基盤を追加

### DIFF
--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -578,6 +578,11 @@ ANSI エスケープの除去、severity の判定、サービス名の設定、
               # zerolog の ConsoleWriter 形式は ANSI カラーエスケープを含む。
               # 先に除去しないと後続の正規表現がレベル表記に一致しない。
               - replace_pattern(body, "\\x1b\\[[0-9;]*m", "") where IsString(body)
+              # filelog receiver の container operator は本文を文字列のまま body に
+              # 入れるため、JSON ログも自動ではパースされない。明示的にパースして
+              # map に変換することで、level の判定と Mackerel 画面での属性検索が効く。
+              - set(body, ParseJSON(body))
+                  where IsString(body) and IsMatch(body, "^\\s*\\{")
               # JSON ログは level フィールドから判定する
               - set(severity_number, SEVERITY_NUMBER_ERROR)
                   where not IsString(body) and body["level"] == "error"

--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -25,14 +25,29 @@
 
 ```bash
 # kustomize build がすべてのディレクトリで通ることを確認する
-go run ./cmd/build-manifests
+mise exec -- go run ./cmd/build-manifests
+
+# YAML のキー順序を含む lint
+mise exec -- pnpm eslint --fix
+mise exec -- pnpm eslint
 
 # マニフェストの静的検査
 mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
-
-# YAML のキー順序を含む lint
-pnpm eslint
 ```
+
+**kube-linter はリポジトリ全体で 633 件の既存の指摘を出す**（2026-08-01 時点のベースライン）。
+`exit code 1` は正常であり、判定は「変更によって新規の指摘が増えていないこと」で行う。
+
+```bash
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s > /tmp/after.log 2>&1
+git stash
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s > /tmp/before.log 2>&1
+git stash pop
+diff /tmp/before.log /tmp/after.log && echo "新規の指摘なし"
+```
+
+`go`、`pnpm`、`kubectl`、`kustomize`、`kube-linter` はいずれも **mise 経由で実行する**。
+システムの PATH には入っていないか、バージョンが mise.toml と不一致である。
 
 ---
 
@@ -119,13 +134,17 @@ configMapGenerator:
 - [ ] **Step 4: ビルドと lint を通す**
 
 ```bash
-go run ./cmd/build-manifests
-pnpm eslint --fix
-pnpm eslint
+mise exec -- go run ./cmd/build-manifests
+mise exec -- pnpm eslint --fix
+mise exec -- pnpm eslint
 mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
 ```
 
-期待：いずれもエラーなし。`build-manifests` は `k8s/apps/nebula` を含む全ディレクトリのビルドに成功する。
+kube-linter は既存の 633 件を出力し exit code 1 で終了する。
+「全タスク共通の検証コマンド」節の手順でベースラインと diff を取り、
+**新規の指摘が増えていないこと**を確認する。
+
+期待：`build-manifests` と `eslint` はエラーなし。`build-manifests` は `k8s/apps/nebula` を含む全ディレクトリのビルドに成功する。kube-linter はベースラインとの diff が空である。
 
 - [ ] **Step 5: コミット**
 
@@ -233,13 +252,17 @@ logs:
 - [ ] **Step 3: ビルドと lint を通す**
 
 ```bash
-go run ./cmd/build-manifests
-pnpm eslint --fix
-pnpm eslint
+mise exec -- go run ./cmd/build-manifests
+mise exec -- pnpm eslint --fix
+mise exec -- pnpm eslint
 mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
 ```
 
-期待：いずれもエラーなし。
+kube-linter は既存の 633 件を出力し exit code 1 で終了する。
+「全タスク共通の検証コマンド」節の手順でベースラインと diff を取り、
+**新規の指摘が増えていないこと**を確認する。
+
+期待：`build-manifests` と `eslint` はエラーなし。kube-linter はベースラインとの diff が空である。
 
 - [ ] **Step 4: コミット**
 
@@ -393,13 +416,17 @@ resources:
 - [ ] **Step 4: ビルドと lint を通す**
 
 ```bash
-go run ./cmd/build-manifests
-pnpm eslint --fix
-pnpm eslint
+mise exec -- go run ./cmd/build-manifests
+mise exec -- pnpm eslint --fix
+mise exec -- pnpm eslint
 mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
 ```
 
-期待：いずれもエラーなし。
+kube-linter は既存の 633 件を出力し exit code 1 で終了する。
+「全タスク共通の検証コマンド」節の手順でベースラインと diff を取り、
+**新規の指摘が増えていないこと**を確認する。
+
+期待：`build-manifests` と `eslint` はエラーなし。kube-linter はベースラインとの diff が空である。
 `kube-linter` が `run-as-non-root` や `privileged-container` を指摘する場合、`podSecurityContext` と `securityContext` の設定が Helm chart のどのキーに対応しているかを確認する。chart によってはコンテナ単位の securityContext のキー名が異なる。
 
 - [ ] **Step 5: 生成されるマニフェストの securityContext を目視確認する**
@@ -584,11 +611,15 @@ ANSI エスケープの除去、severity の判定、サービス名の設定、
 - [ ] **Step 2: ビルドと lint を通す**
 
 ```bash
-go run ./cmd/build-manifests
-pnpm eslint --fix
-pnpm eslint
+mise exec -- go run ./cmd/build-manifests
+mise exec -- pnpm eslint --fix
+mise exec -- pnpm eslint
 mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
 ```
+
+kube-linter は既存の 633 件を出力し exit code 1 で終了する。
+「全タスク共通の検証コマンド」節の手順でベースラインと diff を取り、
+**新規の指摘が増えていないこと**を確認する。
 
 - [ ] **Step 3: processors 配列の順序が保たれていることを確認する**
 
@@ -718,11 +749,15 @@ mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=500 \
 - [ ] **Step 2: ビルドと lint を通す**
 
 ```bash
-go run ./cmd/build-manifests
-pnpm eslint --fix
-pnpm eslint
+mise exec -- go run ./cmd/build-manifests
+mise exec -- pnpm eslint --fix
+mise exec -- pnpm eslint
 mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
 ```
+
+kube-linter は既存の 633 件を出力し exit code 1 で終了する。
+「全タスク共通の検証コマンド」節の手順でベースラインと diff を取り、
+**新規の指摘が増えていないこと**を確認する。
 
 `kube-linter` が `read-secret-from-env-var` を指摘しないことを確認する。このチェックは `.kube-linter.yaml` で除外済みである。
 
@@ -905,11 +940,15 @@ Kubernetes API のみを参照しホストのファイルを読まないため�
 - [ ] **Step 2: ビルドと lint を通す**
 
 ```bash
-go run ./cmd/build-manifests
-pnpm eslint --fix
-pnpm eslint
+mise exec -- go run ./cmd/build-manifests
+mise exec -- pnpm eslint --fix
+mise exec -- pnpm eslint
 mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
 ```
+
+kube-linter は既存の 633 件を出力し exit code 1 で終了する。
+「全タスク共通の検証コマンド」節の手順でベースラインと diff を取り、
+**新規の指摘が増えていないこと**を確認する。
 
 - [ ] **Step 3: 2 つのリリースが別々の名前で生成されることを確認する**
 
@@ -1064,11 +1103,15 @@ loki.source.journal "node_systemd_journal" {
 - [ ] **Step 3: ビルドと lint を通す**
 
 ```bash
-go run ./cmd/build-manifests
-pnpm eslint --fix
-pnpm eslint
+mise exec -- go run ./cmd/build-manifests
+mise exec -- pnpm eslint --fix
+mise exec -- pnpm eslint
 mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
 ```
+
+kube-linter は既存の 633 件を出力し exit code 1 で終了する。
+「全タスク共通の検証コマンド」節の手順でベースラインと diff を取り、
+**新規の指摘が増えていないこと**を確認する。
 
 `config.alloy` は `k8s/**/config/**` に該当するため `yml/file-extension` の対象外である。River 形式のファイルは ESLint の検査対象にならない。
 

--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -1,0 +1,1188 @@
+# Mackerel ログ送信基盤 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** lily クラスタの Pod ログ、journald、Kubernetes Events を OpenTelemetry Collector 経由で Mackerel に送る基盤を用意する。
+
+**Architecture:** OpenTelemetry Collector を DaemonSet（Pod ログ）と Deployment（Kubernetes Events）の 2 リリースで新設し、Mackerel への送信を Collector に一元化する。journald は `journalctl` を持たない公式イメージの制約から、既存の Alloy に読み取らせて OTLP で Collector に渡す。既存の Alloy と Loki の経路は評価期間中そのまま並走させる。
+
+**Tech Stack:** Kubernetes, Kustomize, Helm, OpenTelemetry Collector (`otel/opentelemetry-collector-k8s`), Grafana Alloy, ArgoCD, 1Password Connect
+
+設計の根拠は `docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md` にある。
+
+## Global Constraints
+
+- **YAML のキー順序は ESLint が強制する**。`k8s/**/*.{yml,yaml}` に `yml/sort-keys` が適用され、トップレベルは `apiVersion`, `kind`, `metadata`, `namespace`, `type`, `spec`, `images`, `helmCharts`, `commonLabels`, `resources`, `configMapGenerator` の順、それ以外は昇順（asc）である。`metadata` 配下は `name`, `namespace`, `annotations`, 以降昇順。**各タスクのコミット前に `pnpm eslint --fix` を実行する**。
+- **kube-linter は `addAllBuiltIn: true`** で動作する。除外は `.kube-linter.yaml` に列挙されたものだけで、`privileged-container`、`run-as-non-root`、`no-read-only-root-fs`、`privilege-escalation-container`、`unset-capabilities` は有効である。
+- **Collector は非 root（uid 10001）で動かす**。`privileged: false`、`allowPrivilegeEscalation: false`、`capabilities.drop: [ALL]`、`readOnlyRootFilesystem: true`、`seccompProfile.type: RuntimeDefault` を必ず設定する。
+- **Mackerel の OTLP エンドポイント**：`https://otlp-vaxila.mackerelio.com`、認証ヘッダーは `Mackerel-Api-Key`。
+- **Mackerel API キーの 1Password itemPath**：`vaults/4mogpcwrvtvsnpooum4vcevwkm/items/lplwhjpvwu7x4vblj424d67rba`、Secret のキー名は `apiKey`。
+- **稼働中の Alloy の securityContext は変更しない**。Task 7 で `config.alloy` にのみ追記する。
+- **OpenTelemetry Collector chart のバージョン**：`0.159.0`（既存の kustomization と同じ）。
+- **コミットメッセージは日本語の Conventional Commits 形式**とし、`Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` を付ける。
+
+### 全タスク共通の検証コマンド
+
+```bash
+# kustomize build がすべてのディレクトリで通ることを確認する
+go run ./cmd/build-manifests
+
+# マニフェストの静的検査
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
+
+# YAML のキー順序を含む lint
+pnpm eslint
+```
+
+---
+
+## File Structure
+
+| ファイル | 責務 |
+| --- | --- |
+| `k8s/apps/nebula/kustomization.yaml` | nebula のログレベル設定（Task 1） |
+| `k8s/system/traefik/lily/values.yaml` | Traefik のアクセスログのフィールド設定（Task 2） |
+| `k8s/system/opentelemetry-collector/resources/namespace.yaml` | Namespace（既存、変更なし） |
+| `k8s/system/opentelemetry-collector/resources/secret.yaml` | Mackerel API キーの配布（Task 3 で新規作成） |
+| `k8s/system/opentelemetry-collector/kustomization.yaml` | Collector の Helm リリース 2 つ（Task 3, 4, 5, 6 で段階的に構築） |
+| `k8s/system/argo-cd/resources/application-set-lily.yaml` | ArgoCD への登録（Task 3） |
+| `k8s/apps/grafana-alloy/config/config.alloy` | journald の OTLP 橋渡し（Task 7） |
+
+---
+
+## Task 1: nebula のログレベル是正
+
+nebula backend が DEBUG レベルで SQL クエリの全文を出力しており、クラスタ全体のログ量の 58%（1.72 GB/日）を占めている。
+backend と worker は同じ `backend-config` ConfigMap を参照しているため、1 行の追加で両方に効く。
+
+**Files:**
+- Modify: `k8s/apps/nebula/kustomization.yaml:87-100`（`configMapGenerator` の `backend-config`）
+
+- [ ] **Step 1: 変更前のログ量を記録する**
+
+```bash
+mise exec -- kubectl get --raw \
+  "/api/v1/namespaces/grafana-loki/services/loki:3100/proxy/loki/api/v1/query?query=sum(bytes_over_time(%7Bnamespace%3D%22nebula%22%7D%5B1h%5D))"
+```
+
+出力の `value[1]` を控える。基準値は約 7.5e7（75 MB/h）である。
+
+- [ ] **Step 2: アプリケーションが `LOG_LEVEL` を参照するか確認する**
+
+nebula のアプリケーションが実際にこの環境変数を読むかは未確認である。
+まず現在の Deployment に設定されている環境変数を確認する。
+イメージが distroless の場合 `kubectl exec` で `env` を実行できないため、マニフェストから読む。
+
+```bash
+mise exec -- kubectl get deploy backend -n nebula \
+  -o jsonpath='{.spec.template.spec.containers[0].env[*].name}{"\n"}'
+mise exec -- kubectl get cm -n nebula -o name | grep backend-config
+```
+
+調査時点では `SERVER_ADDRESS` のみが設定されており、ログレベルの指定は存在しなかった。
+
+次に nebula アプリケーションのソースで設定名を確認する。
+
+```bash
+gh search code --repo SlashNephy/nebula "LOG_LEVEL" --limit 5 \
+  || echo "GitHub 検索で見つからない。リポジトリを clone して確認する"
+```
+
+`LOG_LEVEL` 以外の名前だった場合は、以降のステップの変数名をその名前に置き換える。
+設定名が特定できない場合は、この Task を中断してユーザーに確認する。
+発生源の是正は Collector 側の除外でも代替できるが、その判断はユーザーが行う。
+
+- [ ] **Step 3: ConfigMap にログレベルを追加する**
+
+`k8s/apps/nebula/kustomization.yaml` の `configMapGenerator` を次のように変更する。
+`literals` は既存の並びを保ち、末尾に追加する（`yml/sort-sequence-values` の対象外であることを `pnpm eslint` で確認する）。
+
+```yaml
+configMapGenerator:
+  - name: backend-config
+    literals:
+      - SERVER_ORIGIN=https://nebula.starry.blue
+      - FRONTEND_ORIGIN=https://nebula.starry.blue
+      - COOKIE_DOMAIN=nebula.starry.blue
+      - MEDIA_STORAGE_LOCAL_DIRECTORY=/app/media
+      - AVATAR_STORAGE_LOCAL_DIRECTORY=/app/avatars
+      - THUMBNAIL_STORAGE_LOCAL_DIRECTORY=/app/thumbnails
+      - ML_BASE_URL=http://ml:8083
+      - XCTID_BASE_URL=http://xctid:8084
+      - INSTAGRAM_BASE_URL=http://instagram:8085
+      - YTDLP_BASE_URL=http://ytdlp:8086
+      - FFMPEG_BASE_URL=http://ffmpeg:8087
+      # DEBUG では SQL クエリの全文が出力され、クラスタ全体のログ量の 58% を占めていた
+      - LOG_LEVEL=info
+```
+
+- [ ] **Step 4: ビルドと lint を通す**
+
+```bash
+go run ./cmd/build-manifests
+pnpm eslint --fix
+pnpm eslint
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
+```
+
+期待：いずれもエラーなし。`build-manifests` は `k8s/apps/nebula` を含む全ディレクトリのビルドに成功する。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add k8s/apps/nebula/kustomization.yaml
+git commit -F - <<'EOF'
+fix(nebula): 本番のログレベルを info に設定
+
+backend がアプリケーションの既定値である DEBUG で稼働しており、
+SQL クエリの全文を出力していた。クラスタ全体のログ量 2.97 GB/日の
+うち 1.72 GB/日 (58%) をこのデバッグログが占めていた。
+
+backend と worker は同じ ConfigMap を参照するため、両方に効く。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+- [ ] **Step 6: デプロイ後にログ量の減少を確認する**
+
+ArgoCD が同期し Pod が再起動した後、Step 1 と同じクエリを実行する。
+
+```bash
+mise exec -- kubectl rollout status deploy/backend -n nebula --timeout=5m
+# Pod 再起動から 1 時間以上経過してから実行する
+mise exec -- kubectl get --raw \
+  "/api/v1/namespaces/grafana-loki/services/loki:3100/proxy/loki/api/v1/query?query=sum(bytes_over_time(%7Bnamespace%3D%22nebula%22%7D%5B1h%5D))"
+```
+
+期待：約 7.5e7 から 1.0e7 程度（10 MB/h 前後）に減少する。
+減少しない場合、アプリケーションが `LOG_LEVEL` を参照していない。Step 2 に戻る。
+
+---
+
+## Task 2: Traefik のアクセスログのヘッダー削減
+
+Traefik のアクセスログは 1 レコード平均 3,554 bytes で、その 73.5% を HTTP ヘッダーが占めている。
+`defaultmode` を `keep` から `drop` に反転し、必要なヘッダーだけを明示的に残す。
+
+**Files:**
+- Modify: `k8s/system/traefik/lily/values.yaml:79-96`（`logs.access.fields`）
+
+- [ ] **Step 1: 変更前のレコードサイズを記録する**
+
+```bash
+mise exec -- kubectl logs -n traefik -l app.kubernetes.io/name=traefik --tail=500 \
+  | python3 -c "
+import sys
+lines = [l for l in sys.stdin if l.startswith('{')]
+print(f'{len(lines)} 行, 平均 {sum(len(l) for l in lines)/len(lines):.0f} bytes/rec')
+"
+```
+
+期待：平均 3,500 bytes 前後。
+
+- [ ] **Step 2: values.yaml のヘッダー設定を反転する**
+
+`k8s/system/traefik/lily/values.yaml` の `logs.access.fields.headers` を次のように置き換える。
+`general` セクションは変更しない。
+
+```yaml
+logs:
+  access:
+    enabled: true
+    # https://docs.traefik.io/observability/access-logs/#limiting-the-fieldsincluding-headers
+    fields:
+      general:
+        defaultmode: keep
+        names:
+          ClientAddr: drop # ClientHost:ClientPort の組み合わせなので不要
+          StartLocal: drop # time で十分
+          StartUTC: drop
+      headers:
+        # 全ヘッダーを記録すると 1 レコード 3,554 bytes に達し、その 73.5% を
+        # ヘッダーが占めていた。drop を既定にすることで、新しい機密ヘッダーが
+        # 増えても明示的に keep しない限りログに載らない。
+        defaultmode: drop
+        names:
+          Accept-Language: keep
+          # Cloudflare のジオ情報。緯度経度 (Cf-Iplatitude/Cf-Iplongitude)、
+          # 郵便番号、タイムゾーンは所在地の特定精度が高すぎるため keep しない。
+          Cf-Connecting-Ip: keep
+          Cf-Ipcity: keep
+          Cf-Ipcountry: keep
+          Cf-Ray: keep
+          Cf-Visitor: keep
+          Origin: keep
+          Referer: keep
+          Sec-Ch-Ua: keep
+          Sec-Ch-Ua-Mobile: keep
+          Sec-Ch-Ua-Platform: keep
+          Sec-Fetch-Dest: keep
+          Sec-Fetch-Mode: keep
+          Sec-Fetch-Site: keep
+          User-Agent: keep
+          X-Real-Ip: keep
+    format: json
+  general:
+    level: INFO
+```
+
+`Authorization`、`Cookie`、`X-Authentik-Jwt` の `redact` 指定は削除する。
+`defaultmode: drop` により、これらは明示的に keep しない限り記録されない。
+
+- [ ] **Step 3: ビルドと lint を通す**
+
+```bash
+go run ./cmd/build-manifests
+pnpm eslint --fix
+pnpm eslint
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
+```
+
+期待：いずれもエラーなし。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add k8s/system/traefik/lily/values.yaml
+git commit -F - <<'EOF'
+perf(traefik): アクセスログのヘッダーを必要なものだけに絞る
+
+1 レコード平均 3,554 bytes のうち 73.5% を HTTP ヘッダーが占めており、
+origin_* は downstream_* とほぼ重複、固定セキュリティヘッダーは毎回
+同じ値を返すため情報量がなかった。
+
+defaultmode を drop に反転し、クライアント識別とジオ情報に必要な 16 個
+のみを keep する。これにより Authorization と Cookie の redact 指定が
+不要になり、新しい機密ヘッダーが増えても指定漏れが起きなくなる。
+
+Cloudflare の緯度経度と郵便番号は所在地の特定精度が高いため keep しない。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+- [ ] **Step 5: デプロイ後にレコードサイズの減少を確認する**
+
+```bash
+mise exec -- kubectl rollout status deploy/traefik -n traefik --timeout=5m
+```
+
+Step 1 と同じコマンドを実行する。
+期待：平均 1,400 bytes 前後（約 60% 減）。
+
+あわせて機密ヘッダーが記録されていないことを確認する。
+
+```bash
+COUNT=$(mise exec -- kubectl logs -n traefik -l app.kubernetes.io/name=traefik --tail=500 \
+  | grep -ciE '"(request|downstream|origin)_(authorization|cookie|x-authentik-jwt)"' || true)
+echo "機密ヘッダーを含む行: ${COUNT}"
+```
+
+期待：`0` である。
+0 でない場合、`defaultmode: drop` が反映されていない。Pod が再起動しているかを確認する。
+
+---
+
+## Task 3: Collector の土台と Pod ログの読み取り確認
+
+Collector を非 root で立ち上げ、`/var/log/pods` を読めることを確認する。
+このタスクでは Mackerel には送らず、`debug` exporter で読み取りだけを検証する。
+非 root での読み取り可否が設計上最大の未検証事項であり、先に潰しておく。
+
+**Files:**
+- Create: `k8s/system/opentelemetry-collector/resources/secret.yaml`
+- Modify: `k8s/system/opentelemetry-collector/kustomization.yaml`（全面書き換え）
+- Modify: `k8s/system/argo-cd/resources/application-set-lily.yaml`（`system` セクションに追加）
+
+**Interfaces:**
+- Produces: Namespace `opentelemetry-collector`、Secret `mackerel-api-key`（キー `apiKey`）、Helm リリース `otel-agent`（DaemonSet）
+
+- [ ] **Step 1: Secret のマニフェストを作成する**
+
+`k8s/system/opentelemetry-collector/resources/secret.yaml` を新規作成する。
+既存の `k8s/system/mackerel-operator/resources/secret.yaml` と同じ 1Password のアイテムを参照する。
+
+```yaml
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: mackerel-api-key
+
+spec:
+  itemPath: vaults/4mogpcwrvtvsnpooum4vcevwkm/items/lplwhjpvwu7x4vblj424d67rba
+```
+
+- [ ] **Step 2: kustomization.yaml を書き換える**
+
+`k8s/system/opentelemetry-collector/kustomization.yaml` を全面的に置き換える。
+既存の設定は `mode: deployment` でありながら DaemonSet 前提の `logsCollection` preset を有効にしており、そのままでは使えない。
+
+このステップでは `debug` exporter のみを設定し、Mackerel には送らない。
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opentelemetry-collector
+
+helmCharts:
+  # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
+  - name: opentelemetry-collector
+    releaseName: otel-agent
+    namespace: opentelemetry-collector
+    version: 0.159.0
+    repo: https://open-telemetry.github.io/opentelemetry-helm-charts
+    valuesInline:
+      config:
+        exporters:
+          debug:
+            verbosity: basic
+        service:
+          pipelines:
+            logs:
+              exporters:
+                - debug
+      image:
+        repository: otel/opentelemetry-collector-k8s
+      mode: daemonset
+      podSecurityContext:
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+        # /var/log/pods 配下のログファイルが 0640 root:root であるため、
+        # 読み取りには root グループへの所属が必要になる
+        supplementalGroups:
+          - 0
+      presets:
+        kubernetesAttributes:
+          enabled: true
+          extractAllPodAnnotations: true
+          extractAllPodLabels: true
+        logsCollection:
+          enabled: true
+          includeCollectorLogs: false
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+
+resources:
+  - ./resources/namespace.yaml
+  - ./resources/secret.yaml
+```
+
+`logsCollection` preset の `storeCheckpoints` は設定しない。
+既定値の `false` のままとする。有効にすると `/var/lib/otelcol` への書き込みが必要になり、`readOnlyRootFilesystem: true` と両立しない。
+
+- [ ] **Step 3: ApplicationSet に登録する**
+
+`k8s/system/argo-cd/resources/application-set-lily.yaml` の `# system` セクション、`mackerel-operator` のエントリの後に追加する。
+
+```yaml
+          - name: opentelemetry-collector
+            namespace: opentelemetry-collector
+            path: k8s/system/opentelemetry-collector
+            project: system
+```
+
+- [ ] **Step 4: ビルドと lint を通す**
+
+```bash
+go run ./cmd/build-manifests
+pnpm eslint --fix
+pnpm eslint
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
+```
+
+期待：いずれもエラーなし。
+`kube-linter` が `run-as-non-root` や `privileged-container` を指摘する場合、`podSecurityContext` と `securityContext` の設定が Helm chart のどのキーに対応しているかを確認する。chart によってはコンテナ単位の securityContext のキー名が異なる。
+
+- [ ] **Step 5: 生成されるマニフェストの securityContext を目視確認する**
+
+```bash
+mise exec -- kustomize build --enable-helm k8s/system/opentelemetry-collector \
+  | python3 -c "
+import sys, yaml
+for doc in yaml.safe_load_all(sys.stdin):
+    if doc and doc.get('kind') == 'DaemonSet':
+        spec = doc['spec']['template']['spec']
+        print('pod securityContext:', spec.get('securityContext'))
+        for c in spec['containers']:
+            print(f\"container {c['name']} securityContext:\", c.get('securityContext'))
+"
+```
+
+期待：pod 側に `runAsNonRoot: True`、`runAsUser: 10001`、`supplementalGroups: [0]` が、container 側に `allowPrivilegeEscalation: False`、`capabilities: {'drop': ['ALL']}`、`readOnlyRootFilesystem: True`、`privileged: False` が出力される。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add k8s/system/opentelemetry-collector k8s/system/argo-cd/resources/application-set-lily.yaml
+git commit -F - <<'EOF'
+feat(opentelemetry-collector): 非 root の DaemonSet で Pod ログを読む
+
+Mackerel へのログ送信基盤の土台を用意する。まず debug exporter のみを
+設定し、非 root で /var/log/pods を読めることを検証する。
+
+ノード上のログファイルは 0640 root:root であるため、supplementalGroups
+に root グループを付与することで uid 0 を使わずに読み取れる。
+
+既存の設定は mode: deployment でありながら DaemonSet 前提の
+logsCollection preset を有効にしており、そのままでは使えないため
+全面的に書き換えた。ApplicationSet にも未登録だったため追加する。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+- [ ] **Step 7: デプロイして非 root での読み取りを検証する**
+
+ArgoCD の同期を待つ。
+
+```bash
+mise exec -- kubectl rollout status ds/otel-agent-opentelemetry-collector-agent \
+  -n opentelemetry-collector --timeout=5m
+```
+
+DaemonSet の名前は chart のバージョンによって変わる。実際の名前を確認する。
+
+```bash
+mise exec -- kubectl get ds -n opentelemetry-collector
+```
+
+Pod が非 root で動いていることを確認する。
+
+```bash
+POD=$(mise exec -- kubectl get pod -n opentelemetry-collector -o name | head -1)
+mise exec -- kubectl get "$POD" -n opentelemetry-collector \
+  -o jsonpath='{.spec.securityContext}{"\n"}{.spec.containers[0].securityContext}{"\n"}'
+```
+
+期待：`runAsNonRoot: true`、`runAsUser: 10001` が含まれる。
+
+ログを実際に読めていることを確認する。
+
+```bash
+mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=50 | grep -E "LogsExporter|log records"
+```
+
+期待：`LogsExporter` の行に `#log records` が 0 より大きい値で出力される。
+
+エラーが出る場合は次を確認する。
+
+```bash
+mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=100 | grep -iE "permission denied|error"
+```
+
+`permission denied` が出る場合、`supplementalGroups: [0]` では不足している。
+その場合は `podSecurityContext` を `runAsUser: 0` に変更し、`runAsNonRoot` を削除して再デプロイする（他の securityContext 項目は維持する）。設計文書の未決事項に結果を追記する。
+
+---
+
+## Task 4: ログ変換パイプラインの構築
+
+ANSI エスケープの除去、severity の判定、サービス名の設定、オプトアウト判定、サンプリングを組み立てる。
+このタスクでも exporter は `debug` のままとし、変換結果を目視で確認する。
+
+**Files:**
+- Modify: `k8s/system/opentelemetry-collector/kustomization.yaml`（`config` セクション）
+
+**Interfaces:**
+- Consumes: Task 3 で作成した `otel-agent` の Helm リリース
+- Produces: リソース属性 `service.namespace`、`service.name`、ログレコード属性 `sample_priority`
+
+- [ ] **Step 1: config セクションを書き換える**
+
+`kustomization.yaml` の `valuesInline.config` を次の内容に置き換える。
+`presets` と `securityContext` などの他のキーは Task 3 のまま変更しない。
+
+```yaml
+      config:
+        exporters:
+          debug:
+            # 変換結果を目視で確認するため detailed にする。
+            # Task 5 で Mackerel exporter に切り替える際に削除する。
+            verbosity: detailed
+        processors:
+          # 除外対象を先に落とし、後続の変換コストを減らす
+          filter/optout:
+            error_mode: ignore
+            logs:
+              log_record:
+                - 'resource.attributes["k8s.pod.annotation.mackerel.io/logs"] == "false"'
+          probabilistic_sampler:
+            # 初期値は 100%。発生源の是正により全量でも月 720 円に収まるため、
+            # まず全量送信して実データを確認する。
+            sampling_percentage: 100
+            sampling_priority: sample_priority
+          transform/sampling:
+            error_mode: ignore
+            log_statements:
+              # WARN 以上は優先度 100 を付与し、サンプリング率に関わらず必ず通す
+              - set(attributes["sample_priority"], 100)
+                  where severity_number >= SEVERITY_NUMBER_WARN
+          transform/service_name:
+            error_mode: ignore
+            log_statements:
+              - set(resource.attributes["service.namespace"],
+                    resource.attributes["k8s.namespace.name"])
+              - set(resource.attributes["service.name"],
+                    resource.attributes["k8s.deployment.name"])
+                  where resource.attributes["k8s.deployment.name"] != nil
+              - set(resource.attributes["service.name"],
+                    resource.attributes["k8s.daemonset.name"])
+                  where resource.attributes["service.name"] == nil
+                    and resource.attributes["k8s.daemonset.name"] != nil
+              - set(resource.attributes["service.name"],
+                    resource.attributes["k8s.statefulset.name"])
+                  where resource.attributes["service.name"] == nil
+                    and resource.attributes["k8s.statefulset.name"] != nil
+              - set(resource.attributes["service.name"],
+                    resource.attributes["k8s.pod.name"])
+                  where resource.attributes["service.name"] == nil
+          transform/severity:
+            error_mode: ignore
+            log_statements:
+              # zerolog の ConsoleWriter 形式は ANSI カラーエスケープを含む。
+              # 先に除去しないと後続の正規表現がレベル表記に一致しない。
+              - replace_pattern(body, "\\x1b\\[[0-9;]*m", "") where IsString(body)
+              # JSON ログは level フィールドから判定する
+              - set(severity_number, SEVERITY_NUMBER_ERROR)
+                  where not IsString(body) and body["level"] == "error"
+              - set(severity_number, SEVERITY_NUMBER_WARN)
+                  where not IsString(body) and body["level"] == "warn"
+              - set(severity_number, SEVERITY_NUMBER_INFO)
+                  where not IsString(body) and body["level"] == "info"
+              # テキストログは本文から推定する。zerolog の ERR / WRN 表記にも対応する
+              - set(severity_number, SEVERITY_NUMBER_ERROR)
+                  where IsString(body)
+                    and IsMatch(body, "(?i)\\b(err|error|fatal|panic)\\b")
+              - set(severity_number, SEVERITY_NUMBER_WARN)
+                  where IsString(body)
+                    and severity_number == SEVERITY_NUMBER_UNSPECIFIED
+                    and IsMatch(body, "(?i)\\b(wrn|warn|warning)\\b")
+        service:
+          pipelines:
+            logs:
+              exporters:
+                - debug
+              processors:
+                - filter/optout
+                - transform/severity
+                - transform/service_name
+                - transform/sampling
+                - probabilistic_sampler
+```
+
+`processors` の並びは ESLint により昇順に整列されるが、`service.pipelines.logs.processors` は配列であり**実行順序を持つ**。この配列の順序は変更してはならない。`pnpm eslint --fix` の実行後に、この配列の順序が保たれていることを必ず確認する。
+
+- [ ] **Step 2: ビルドと lint を通す**
+
+```bash
+go run ./cmd/build-manifests
+pnpm eslint --fix
+pnpm eslint
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
+```
+
+- [ ] **Step 3: processors 配列の順序が保たれていることを確認する**
+
+```bash
+grep -A8 "processors:" k8s/system/opentelemetry-collector/kustomization.yaml | grep -A7 "filter/optout"
+```
+
+期待：`filter/optout`, `transform/severity`, `transform/service_name`, `transform/sampling`, `probabilistic_sampler` の順で並んでいる。
+順序が変わっている場合、`pnpm eslint --fix` が配列を並び替えている。`eslint.config.mjs` の `yml/sort-sequence-values` の設定を確認し、該当パスが対象外であることを確かめる。対象になっている場合はこの配列に `# eslint-disable-next-line yml/sort-sequence-values` を付けるのではなく、ユーザーに相談する。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add k8s/system/opentelemetry-collector/kustomization.yaml
+git commit -F - <<'EOF'
+feat(opentelemetry-collector): ログ変換パイプラインを構築
+
+ANSI エスケープの除去、severity の判定、サービス名の設定、
+オプトアウト判定、サンプリングを組み立てる。
+
+nebula のログは zerolog の ConsoleWriter 形式で ANSI カラーエスケープを
+含むため、除去を最初に行う。順序を誤ると後続の正規表現が一致しない。
+
+サンプリングは WARN 以上に優先度 100 を付与して常に通す。初期の
+サンプリング率は 100% とし、実データを見てから調整する。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+- [ ] **Step 5: 変換結果を確認する**
+
+ArgoCD の同期を待つ。
+`syncPolicy` は `selfHeal: true` であるため、`kubectl apply` による手動変更は数分で巻き戻される。
+確認はコミット済みの状態に対して行う。
+
+```bash
+mise exec -- kubectl rollout status ds -n opentelemetry-collector --timeout=5m
+POD=$(mise exec -- kubectl get pod -n opentelemetry-collector -o name | head -1)
+```
+
+サービス名と severity が設定されていることを確認する。
+
+```bash
+mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=300 \
+  | grep -E "service\.name|service\.namespace|SeverityNumber" | head -20
+```
+
+期待：`service.namespace` に namespace 名、`service.name` にワークロード名、`SeverityNumber` に `Info(9)` や `Error(17)` などが出力される。
+`SeverityNumber` がすべて `Unspecified(0)` の場合、severity 判定が機能していない。`transform/severity` の OTTL 式を見直す。
+
+ANSI エスケープが除去されていることを確認する。
+
+```bash
+COUNT=$(mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=300 \
+  | grep -c $'\033\[' || true)
+echo "ANSI エスケープを含む行: ${COUNT}"
+```
+
+期待：`0` である。
+0 でない場合、`replace_pattern` の正規表現が RE2 で `\x1b` を解釈できていない。`\\x1b` を `\\u001b` に変えて再試行する。
+
+nebula のログで実際に確認する。
+
+```bash
+mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=500 \
+  | grep -A3 'service.name: Str(backend)' | head -12
+```
+
+期待：`Body` に ANSI エスケープを含まない平文が出力され、`SeverityNumber` が設定されている。
+
+---
+
+## Task 5: Mackerel への送信を有効化
+
+`debug` exporter を Mackerel の OTLP exporter に切り替える。
+
+**Files:**
+- Modify: `k8s/system/opentelemetry-collector/kustomization.yaml`（`exporters` と `extraEnvs`）
+
+**Interfaces:**
+- Consumes: Task 3 で作成した Secret `mackerel-api-key`（キー `apiKey`）、Task 4 で構築したパイプライン
+
+- [ ] **Step 1: exporter と環境変数を追加する**
+
+`valuesInline` に `extraEnvs` を追加し、`config.exporters` と `config.service.pipelines.logs.exporters` を書き換える。
+
+```yaml
+      config:
+        exporters:
+          otlphttp/mackerel:
+            endpoint: https://otlp-vaxila.mackerelio.com
+            headers:
+              Mackerel-Api-Key: ${env:MACKEREL_APIKEY}
+            sending_queue:
+              batch:
+                # Mackerel が受け付ける 1 リクエストの上限
+                max_size: 3500000
+                sizer: bytes
+        # (processors は Task 4 のまま変更しない)
+        service:
+          pipelines:
+            logs:
+              exporters:
+                - otlphttp/mackerel
+              processors:
+                - filter/optout
+                - transform/severity
+                - transform/service_name
+                - transform/sampling
+                - probabilistic_sampler
+```
+
+`valuesInline` の直下に `extraEnvs` を追加する（キーは昇順に整列されるため `config` の後、`image` の前になる）。
+
+```yaml
+      extraEnvs:
+        - name: MACKEREL_APIKEY
+          valueFrom:
+            secretKeyRef:
+              key: apiKey
+              name: mackerel-api-key
+```
+
+`debug` exporter は削除する。
+
+- [ ] **Step 2: ビルドと lint を通す**
+
+```bash
+go run ./cmd/build-manifests
+pnpm eslint --fix
+pnpm eslint
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
+```
+
+`kube-linter` が `read-secret-from-env-var` を指摘しないことを確認する。このチェックは `.kube-linter.yaml` で除外済みである。
+
+- [ ] **Step 3: processors 配列の順序を再確認する**
+
+```bash
+grep -A8 "processors:" k8s/system/opentelemetry-collector/kustomization.yaml | grep -A7 "filter/optout"
+```
+
+期待：Task 4 と同じ順序が保たれている。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add k8s/system/opentelemetry-collector/kustomization.yaml
+git commit -F - <<'EOF'
+feat(opentelemetry-collector): Mackerel へのログ送信を有効化
+
+debug exporter を otlphttp exporter に切り替え、Mackerel の OTLP
+エンドポイントに送信する。API キーは 1Password Connect が配布する
+Secret から環境変数で参照する。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+- [ ] **Step 5: 送信されていることを確認する**
+
+```bash
+POD=$(mise exec -- kubectl get pod -n opentelemetry-collector -o name | head -1)
+mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=100 \
+  | grep -iE "error|failed|401|403" || echo "送信エラーなし"
+```
+
+期待：`送信エラーなし` と表示される。
+`401` や `403` が出る場合、Secret のキー名が `apiKey` であること、および API キーに Write 権限があることを確認する。
+
+Collector 自身のメトリクスで送信数を確認する。
+
+```bash
+mise exec -- kubectl exec "$POD" -n opentelemetry-collector -- \
+  wget -qO- http://localhost:8888/metrics 2>/dev/null \
+  | grep -E "otelcol_exporter_sent_log_records_total|otelcol_exporter_send_failed_log_records_total"
+```
+
+イメージに `wget` がない場合は port-forward で取得する。
+
+```bash
+mise exec -- kubectl port-forward -n opentelemetry-collector "$POD" 8888:8888 &
+sleep 3
+curl -s http://localhost:8888/metrics | grep -E "otelcol_exporter_sent_log_records_total|otelcol_exporter_send_failed_log_records_total"
+kill %1
+```
+
+期待：`sent` が 0 より大きく、`send_failed` が 0 である。
+
+- [ ] **Step 6: Mackerel の画面でログを確認する**
+
+Mackerel のログ画面を開き、次を目視で確認する。
+
+- `service.namespace` ごとにサービスが分類されて表示される
+- ログレベルでの絞り込みが機能する
+- WARN 以上のログが届いている
+
+- [ ] **Step 7: オプトアウトの動作を確認する**
+
+既存のワークロードにアノテーションを付ける方法は使えない。
+ArgoCD の `syncPolicy` が `selfHeal: true` であるため、`kubectl patch` による変更は数分で巻き戻される。
+
+代わりに ArgoCD の管理外に検証用の Namespace と Deployment を作る。
+ApplicationSet に登録されていない Namespace であれば、ArgoCD は干渉しない。
+
+```bash
+mise exec -- kubectl create namespace mackerel-optout-test
+mise exec -- kubectl create deployment noisy \
+  -n mackerel-optout-test \
+  --image=busybox:1.37 \
+  -- sh -c 'while true; do echo "optout test $(date)"; sleep 2; done'
+mise exec -- kubectl rollout status deploy/noisy -n mackerel-optout-test --timeout=2m
+```
+
+まず Mackerel の画面で `mackerel-optout-test / noisy` のログが届くことを確認する。
+届いていれば、アノテーションを付けて止まることを確認する。
+
+```bash
+mise exec -- kubectl patch deploy noisy -n mackerel-optout-test \
+  --type=merge \
+  -p '{"spec":{"template":{"metadata":{"annotations":{"mackerel.io/logs":"false"}}}}}'
+mise exec -- kubectl rollout status deploy/noisy -n mackerel-optout-test --timeout=2m
+```
+
+数分待ってから Mackerel の画面で新しいログが止まっていることを確認する。
+
+確認後、検証用リソースを削除する。
+
+```bash
+mise exec -- kubectl delete namespace mackerel-optout-test
+```
+
+この検証は一時的なもので、リポジトリのマニフェストは変更しない。
+
+---
+
+## Task 6: Kubernetes Events の収集
+
+`kubernetesEvents` preset は Deployment を前提とするため、2 つ目の Helm リリースとして追加する。
+
+**Files:**
+- Modify: `k8s/system/opentelemetry-collector/kustomization.yaml`（`helmCharts` に 2 つ目のリリースを追加）
+
+**Interfaces:**
+- Consumes: Task 3 で作成した Secret `mackerel-api-key`
+- Produces: Helm リリース `otel-cluster`（Deployment）
+
+- [ ] **Step 1: 2 つ目の Helm リリースを追加する**
+
+`helmCharts` の配列に、既存の `otel-agent` の後に追加する。
+
+```yaml
+  - name: opentelemetry-collector
+    releaseName: otel-cluster
+    namespace: opentelemetry-collector
+    version: 0.159.0
+    repo: https://open-telemetry.github.io/opentelemetry-helm-charts
+    valuesInline:
+      config:
+        exporters:
+          otlphttp/mackerel:
+            endpoint: https://otlp-vaxila.mackerelio.com
+            headers:
+              Mackerel-Api-Key: ${env:MACKEREL_APIKEY}
+            sending_queue:
+              batch:
+                max_size: 3500000
+                sizer: bytes
+        processors:
+          transform/service_name:
+            error_mode: ignore
+            log_statements:
+              # クラスタ全体のイベントであり、特定の namespace に属さない
+              - set(resource.attributes["service.namespace"], "lily")
+              - set(resource.attributes["service.name"], "kubernetes-events")
+        service:
+          pipelines:
+            logs:
+              exporters:
+                - otlphttp/mackerel
+              processors:
+                - transform/service_name
+      extraEnvs:
+        - name: MACKEREL_APIKEY
+          valueFrom:
+            secretKeyRef:
+              key: apiKey
+              name: mackerel-api-key
+      image:
+        repository: otel/opentelemetry-collector-k8s
+      mode: deployment
+      podSecurityContext:
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      presets:
+        kubernetesEvents:
+          enabled: true
+      replicaCount: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+```
+
+Kubernetes API のみを参照しホストのファイルを読まないため、`supplementalGroups` は設定しない。
+
+- [ ] **Step 2: ビルドと lint を通す**
+
+```bash
+go run ./cmd/build-manifests
+pnpm eslint --fix
+pnpm eslint
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
+```
+
+- [ ] **Step 3: 2 つのリリースが別々の名前で生成されることを確認する**
+
+```bash
+mise exec -- kustomize build --enable-helm k8s/system/opentelemetry-collector \
+  | grep -E "^  name: otel-(agent|cluster)" | sort -u
+```
+
+期待：`otel-agent` と `otel-cluster` の両方を含む名前が出力される。
+名前が衝突している場合、`releaseName` が正しく反映されていない。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add k8s/system/opentelemetry-collector/kustomization.yaml
+git commit -F - <<'EOF'
+feat(opentelemetry-collector): Kubernetes Events の収集を追加
+
+kubernetesEvents preset は Deployment を前提とするため、
+DaemonSet とは別の Helm リリースとして追加する。
+
+Kubernetes API のみを参照しホストのファイルを読まないため、
+supplementalGroups は付与せず、より厳格な securityContext を適用する。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+- [ ] **Step 5: イベントが届いていることを確認する**
+
+```bash
+mise exec -- kubectl get deploy -n opentelemetry-collector
+POD=$(mise exec -- kubectl get pod -n opentelemetry-collector -l app.kubernetes.io/instance=otel-cluster -o name | head -1)
+mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=50 \
+  | grep -iE "error|failed" || echo "エラーなし"
+```
+
+Mackerel の画面で `lily / kubernetes-events` のサービスが表示され、Pod の起動やスケジューリングのイベントが届いていることを確認する。
+
+---
+
+## Task 7: journald の橋渡し
+
+Alloy が既に読み取っている journald のログを、OTLP で Collector に転送する。
+Alloy から Mackerel には直接送らない。送信は Collector に一元化する。
+
+**Files:**
+- Modify: `k8s/apps/grafana-alloy/config/config.alloy`
+- Modify: `k8s/system/opentelemetry-collector/kustomization.yaml`（`otel-agent` に `otlp` receiver を追加）
+
+**Interfaces:**
+- Consumes: Task 5 で構築した `otel-agent` の logs パイプライン
+- Produces: `otel-agent` の OTLP receiver（gRPC :4317）
+
+- [ ] **Step 1: Collector に OTLP receiver を追加する**
+
+`otel-agent` の `config` に `receivers` と、journald 専用のパイプラインを追加する。
+Pod ログとは別のパイプラインにする理由は、journald には ANSI エスケープや Kubernetes のメタデータが存在せず、Pod ログ向けの変換が不要なためである。
+
+`config` の `receivers` セクションを追加する。
+
+```yaml
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                  endpoint: 0.0.0.0:4317
+```
+
+`processors` に journald 用のサービス名設定を追加する。
+
+```yaml
+          transform/journald_service_name:
+            error_mode: ignore
+            log_statements:
+              # ノードの systemd ログはクラスタ単位で扱う
+              - set(resource.attributes["service.namespace"], "lily")
+              - set(resource.attributes["service.name"], "systemd")
+```
+
+`service.pipelines` に journald 用のパイプラインを追加する。
+既存の `logs` パイプラインは変更しない。
+
+```yaml
+          service:
+            pipelines:
+              logs:
+                exporters:
+                  - otlphttp/mackerel
+                processors:
+                  - filter/optout
+                  - transform/severity
+                  - transform/service_name
+                  - transform/sampling
+                  - probabilistic_sampler
+              logs/journald:
+                exporters:
+                  - otlphttp/mackerel
+                processors:
+                  - transform/journald_service_name
+                receivers:
+                  - otlp
+```
+
+`logsCollection` preset が生成する `logs` パイプラインの receiver は preset が管理するため、明示的に書かない。
+
+- [ ] **Step 2: Alloy の config に OTLP 転送を追加する**
+
+`k8s/apps/grafana-alloy/config/config.alloy` の末尾に追加する。
+
+```river
+// journald のログを OpenTelemetry Collector に転送する。
+// Collector の公式イメージは distroless で journalctl を含まないため、
+// journald の読み取りだけを Alloy が担い、Mackerel への送信は Collector が行う。
+otelcol.receiver.loki "journald" {
+	output {
+		logs = [otelcol.exporter.otlp.collector.input]
+	}
+}
+
+otelcol.exporter.otlp "collector" {
+	client {
+		endpoint = "otel-agent-opentelemetry-collector-agent.opentelemetry-collector:4317"
+
+		tls {
+			insecure = true
+		}
+	}
+}
+```
+
+エンドポイントの Service 名は実際に生成されたものに合わせる。
+
+```bash
+mise exec -- kubectl get svc -n opentelemetry-collector
+```
+
+既存の `loki.source.journal` の `forward_to` に転送先を追加する。
+`loki.write.default.receiver` は残し、Loki への送信を維持する。
+
+```river
+loki.source.journal "node_systemd_journal" {
+	forward_to    = [
+		loki.write.default.receiver,
+		otelcol.receiver.loki.journald.receiver,
+	]
+	relabel_rules = loki.relabel.node_systemd_journal.rules
+	labels        = {component = "loki.source.journal"}
+}
+```
+
+- [ ] **Step 3: ビルドと lint を通す**
+
+```bash
+go run ./cmd/build-manifests
+pnpm eslint --fix
+pnpm eslint
+mise exec -- kube-linter lint --config .kube-linter.yaml ./k8s
+```
+
+`config.alloy` は `k8s/**/config/**` に該当するため `yml/file-extension` の対象外である。River 形式のファイルは ESLint の検査対象にならない。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add k8s/apps/grafana-alloy/config/config.alloy k8s/system/opentelemetry-collector/kustomization.yaml
+git commit -F - <<'EOF'
+feat(grafana-alloy): journald のログを Collector に橋渡し
+
+OpenTelemetry の journald receiver は journalctl バイナリを実行する
+実装であり、公式イメージ otel/opentelemetry-collector-k8s は distroless
+で sh すら含まないため動作しない。
+
+Alloy の loki.source.journal は libsystemd を直接呼ぶ自前実装であり
+既に稼働しているため、journald の読み取りだけを Alloy に任せ、
+OTLP で Collector に渡す。Mackerel への送信、severity の付与、
+サンプリングはすべて Collector 側で行う。
+
+journald には ANSI エスケープも Kubernetes のメタデータも存在しない
+ため、Pod ログとは別のパイプラインで処理する。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+- [ ] **Step 5: journald のログが Mackerel に届くことを確認する**
+
+Alloy の再起動を待つ。
+
+```bash
+mise exec -- kubectl rollout status ds/alloy -n grafana-alloy --timeout=5m
+```
+
+Alloy 側でエラーが出ていないことを確認する。
+
+```bash
+POD=$(mise exec -- kubectl get pod -n grafana-alloy -o name | head -1)
+mise exec -- kubectl logs "$POD" -n grafana-alloy -c alloy --tail=50 \
+  | grep -iE "error|failed" || echo "Alloy にエラーなし"
+```
+
+Loki への送信が継続していることを確認する。
+
+```bash
+mise exec -- kubectl get --raw \
+  "/api/v1/namespaces/grafana-loki/services/loki:3100/proxy/loki/api/v1/query?query=sum(bytes_over_time(%7Bcomponent%3D%22loki.source.journal%22%7D%5B5m%5D))"
+```
+
+期待：0 より大きい値が返る。
+
+Mackerel の画面で `lily / systemd` のサービスが表示され、`kubelet` や `crio` のログが届いていることを確認する。
+
+---
+
+## 完了後の作業
+
+- [ ] **設計文書の未決事項を更新する**
+
+`docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md` の「未決事項とリスク」節を、実際の検証結果で更新する。特に次の 3 点を確定させる。
+
+- `supplementalGroups: [0]` で Pod ログを読めたか
+- nebula のアプリケーションが `LOG_LEVEL` を参照したか
+- ANSI エスケープ除去の正規表現が実データで機能したか
+
+- [ ] **実際の送信量を計測し、サンプリング率を判断する**
+
+発生源の是正後、1 日以上経過してから Loki の受信量を再計測する。
+
+```bash
+mise exec -- kubectl get --raw \
+  "/api/v1/namespaces/grafana-loki/services/loki:3100/proxy/metrics" \
+  | grep "^loki_distributor_bytes_received_total"
+```
+
+想定は 0.68 GB/日である。
+大きく上回る場合は `probabilistic_sampler` の `sampling_percentage` を下げる。
+その際、trace ID を持たないログのハッシュ種として `attribute_source: record` と `from_attribute` の指定が必要になる。種の選択肢は設計文書の「サンプリング」節を参照する。
+
+- [ ] **PR を作成する**
+
+未完事項が残っている場合は Draft、すべて検証済みなら通常の PR とする。
+本文には次のセクションを含める。
+
+- **概要**：Mackerel へのログ送信基盤を追加したこと
+- **実測データ**：是正前後のログ量の比較（実際に計測した値を記載する）
+- **検証結果**：各タスクの検証ステップの結果。Mackerel の画面はスクリーンショットを添付する
+- **動物界における比擬**：変更点を動物の生態に擬した解説
+
+スクリーンショットの添付には `github-image-upload` スキル（`gh image upload`）を使う。
+
+```bash
+gh pr create \
+  --title "feat: Mackerel へのログ送信基盤を追加" \
+  --body-file <(cat <<'EOF'
+## 概要
+
+lily クラスタの Pod ログ、journald、Kubernetes Events を
+OpenTelemetry Collector 経由で Mackerel に送る基盤を追加する。
+
+設計は `docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md` にある。
+
+## 実測データ
+
+（実際に計測した是正前後の値を記載する）
+
+## 検証結果
+
+（各タスクの検証ステップの結果を記載する）
+
+## 動物界における比擬
+
+（変更点を動物の生態に擬して解説する）
+EOF
+)
+gh pr edit --add-assignee SlashNephy
+```

--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -599,11 +599,16 @@ ANSI エスケープの除去、severity の判定、サービス名の設定、
               exporters:
                 - debug
               processors:
+                # Helm の values マージでは配列は置換されるため、chart が既定で
+                # 入れる memory_limiter と batch を明示的に書き戻す必要がある。
+                # 省略すると logs パイプラインからだけ両者が消える。
+                - memory_limiter
                 - filter/optout
                 - transform/severity
                 - transform/service_name
                 - transform/sampling
                 - probabilistic_sampler
+                - batch
 ```
 
 `processors` の並びは ESLint により昇順に整列されるが、`service.pipelines.logs.processors` は配列であり**実行順序を持つ**。この配列の順序は変更してはならない。`pnpm eslint --fix` の実行後に、この配列の順序が保たれていることを必ず確認する。
@@ -627,7 +632,9 @@ kube-linter は既存の 633 件を出力し exit code 1 で終了する。
 grep -A8 "processors:" k8s/system/opentelemetry-collector/kustomization.yaml | grep -A7 "filter/optout"
 ```
 
-期待：`filter/optout`, `transform/severity`, `transform/service_name`, `transform/sampling`, `probabilistic_sampler` の順で並んでいる。
+期待：`memory_limiter`, `filter/optout`, `transform/severity`, `transform/service_name`, `transform/sampling`, `probabilistic_sampler`, `batch` の順で並んでいる。
+生成後の config では preset が `k8sattributes` を先頭に挿入するため、最終的な並びは
+`k8sattributes, memory_limiter, filter/optout, ..., probabilistic_sampler, batch` になる。
 順序が変わっている場合、`pnpm eslint --fix` が配列を並び替えている。`eslint.config.mjs` の `yml/sort-sequence-values` の設定を確認し、該当パスが対象外であることを確かめる。対象になっている場合はこの配列に `# eslint-disable-next-line yml/sort-sequence-values` を付けるのではなく、ユーザーに相談する。
 
 - [ ] **Step 4: コミット**
@@ -726,11 +733,16 @@ mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=500 \
               exporters:
                 - otlphttp/mackerel
               processors:
+                # Helm の values マージでは配列は置換されるため、chart が既定で
+                # 入れる memory_limiter と batch を明示的に書き戻す必要がある。
+                # 省略すると logs パイプラインからだけ両者が消える。
+                - memory_limiter
                 - filter/optout
                 - transform/severity
                 - transform/service_name
                 - transform/sampling
                 - probabilistic_sampler
+                - batch
 ```
 
 `valuesInline` の直下に `extraEnvs` を追加する（キーは昇順に整列されるため `config` の後、`image` の前になる）。
@@ -906,7 +918,10 @@ mise exec -- kubectl delete namespace mackerel-optout-test
               exporters:
                 - otlphttp/mackerel
               processors:
+                # 配列は置換されるため、chart 既定の memory_limiter と batch を明示する
+                - memory_limiter
                 - transform/service_name
+                - batch
       extraEnvs:
         - name: MACKEREL_APIKEY
           valueFrom:
@@ -1039,16 +1054,22 @@ Pod ログとは別のパイプラインにする理由は、journald には ANS
                 exporters:
                   - otlphttp/mackerel
                 processors:
+                  # Helm の values マージでは配列は置換されるため、chart が既定で
+                  # 入れる memory_limiter と batch を明示的に書き戻す必要がある。
+                  - memory_limiter
                   - filter/optout
                   - transform/severity
                   - transform/service_name
                   - transform/sampling
                   - probabilistic_sampler
+                  - batch
               logs/journald:
                 exporters:
                   - otlphttp/mackerel
                 processors:
+                  - memory_limiter
                   - transform/journald_service_name
+                  - batch
                 receivers:
                   - otlp
 ```

--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -722,6 +722,11 @@ mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=500 \
 ```yaml
       config:
         exporters:
+          # chart は metrics/traces のパイプラインを既定で作り、debug exporter に
+          # 出力する。このリポジトリではログしか扱わず、メトリクスは
+          # mackerel-container-agent が別途送っているため、収集結果を捨てる。
+          # Helm のマージは null を無視するのでパイプラインごとは消せない。
+          nop: {}
           otlphttp/mackerel:
             endpoint: https://otlp-vaxila.mackerelio.com
             headers:
@@ -734,6 +739,12 @@ mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=500 \
         # (processors は Task 4 のまま変更しない)
         service:
           pipelines:
+            metrics:
+              exporters:
+                - nop
+            traces:
+              exporters:
+                - nop
             logs:
               exporters:
                 - otlphttp/mackerel

--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -576,7 +576,7 @@ ANSI エスケープの除去、severity の判定、サービス名の設定、
             error_mode: ignore
             logs:
               log_record:
-                - 'resource.attributes["k8s.pod.annotation.mackerel.io/logs"] == "false"'
+                - 'resource.attributes["mackerel.io/logs"] == "false"'
           probabilistic_sampler:
             # 初期値は 100%。発生源の是正により全量でも月 720 円に収まるため、
             # まず全量送信して実データを確認する。

--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -56,7 +56,7 @@ OTTL 式の誤りは `otelcol validate` でしか検出できない。
 Collector の config を変更したときは必ず実行する。
 
 ```bash
-SB=$(mktemp -d)
+export SB="$(mktemp -d)"
 mise exec -- kustomize build --enable-helm k8s/system/opentelemetry-collector 2>/dev/null \
   | python3 -c "
 import sys, yaml, pathlib, os
@@ -542,7 +542,20 @@ mise exec -- kubectl logs "$POD" -n opentelemetry-collector --tail=100 | grep -i
 ```
 
 `permission denied` が出る場合、`supplementalGroups: [0]` では不足している。
-その場合は `podSecurityContext` を `runAsUser: 0` に変更し、`runAsNonRoot` を削除して再デプロイする（他の securityContext 項目は維持する）。設計文書の未決事項に結果を追記する。
+**`runAsUser: 0` に切り替えてはならない。**
+この Collector は Mackerel API キーを保持しており、root で動かすと侵害時の影響範囲が広がる。
+
+検証をいったん止め、次を調査する。
+
+```bash
+# ログファイルの所有者・グループ・パーミッションを確認する
+mise exec -- kubectl debug node/lily -it --image=busybox -- \
+  sh -c 'ls -ln /host/var/log/pods/*/*/*.log | head -5'
+```
+
+所有グループが root でない、ACL が設定されている、マウント方法が想定と違う、のいずれかである。
+判明した条件に応じて `supplementalGroups` に必要な gid を追加するか、マウント設定を見直す。
+結果は設計文書の未決事項に追記する。
 
 ---
 
@@ -1118,8 +1131,14 @@ Pod ログとは別のパイプラインにする理由は、journald には ANS
                 exporters:
                   - otlphttp/mackerel
                 processors:
+                  # Pod ログと同じ severity 判定とサンプリングを通す。省略すると
+                  # journald だけが常に全量送信され、サンプリング率を下げたときに
+                  # 送信量の見積もりが崩れる。
                   - memory_limiter
+                  - transform/severity
                   - transform/journald_service_name
+                  - transform/sampling
+                  - probabilistic_sampler
                   - batch
                 receivers:
                   - otlp

--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -64,14 +64,19 @@ for doc in yaml.safe_load_all(sys.stdin):
     if doc and doc.get('kind') == 'ConfigMap' and 'agent' in doc['metadata']['name']:
         pathlib.Path(os.environ['SB'] + '/relay.yaml').write_text(doc['data']['relay'])
 "
+# 実際にデプロイされるタグで検証する。chart のバージョンと Collector の
+# バージョンは一致しないため、latest では検証にならない。
+TAG=$(mise exec -- kustomize build --enable-helm k8s/system/opentelemetry-collector 2>/dev/null \
+  | grep -oE 'otel/opentelemetry-collector-k8s:[0-9.]+' | head -1)
 mise exec -- docker run --rm \
   -v "$SB/relay.yaml:/etc/otel/config.yaml:ro" \
   -e MACKEREL_APIKEY=dummy -e MY_POD_IP=127.0.0.1 -e K8S_NODE_NAME=lily \
-  otel/opentelemetry-collector-k8s:latest \
+  "$TAG" \
   validate --config=/etc/otel/config.yaml
 ```
 
 出力が空であれば検証成功である。
+2026-08-01 時点では chart 0.159.0 が Collector 0.154.0 のイメージを指しており、両者は一致しない。
 `otel-cluster` のリリースを追加した後は、ConfigMap 名の判定を `cluster` に変えて同様に検証する。
 
 **OTTL のパスにはコンテキスト名が必要である。**

--- a/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md
@@ -49,6 +49,36 @@ diff /tmp/before.log /tmp/after.log && echo "新規の指摘なし"
 `go`、`pnpm`、`kubectl`、`kustomize`、`kube-linter` はいずれも **mise 経由で実行する**。
 システムの PATH には入っていないか、バージョンが mise.toml と不一致である。
 
+### Collector の設定検証
+
+`kustomize build` が通っても Collector が設定を受け付けるとは限らない。
+OTTL 式の誤りは `otelcol validate` でしか検出できない。
+Collector の config を変更したときは必ず実行する。
+
+```bash
+SB=$(mktemp -d)
+mise exec -- kustomize build --enable-helm k8s/system/opentelemetry-collector 2>/dev/null \
+  | python3 -c "
+import sys, yaml, pathlib, os
+for doc in yaml.safe_load_all(sys.stdin):
+    if doc and doc.get('kind') == 'ConfigMap' and 'agent' in doc['metadata']['name']:
+        pathlib.Path(os.environ['SB'] + '/relay.yaml').write_text(doc['data']['relay'])
+"
+mise exec -- docker run --rm \
+  -v "$SB/relay.yaml:/etc/otel/config.yaml:ro" \
+  -e MACKEREL_APIKEY=dummy -e MY_POD_IP=127.0.0.1 -e K8S_NODE_NAME=lily \
+  otel/opentelemetry-collector-k8s:latest \
+  validate --config=/etc/otel/config.yaml
+```
+
+出力が空であれば検証成功である。
+`otel-cluster` のリリースを追加した後は、ConfigMap 名の判定を `cluster` に変えて同様に検証する。
+
+**OTTL のパスにはコンテキスト名が必要である。**
+`body` ではなく `log.body`、`severity_number` ではなく `log.severity_number`、
+`attributes[...]` ではなく `log.attributes[...]` と書く。
+省略すると `unable to infer context from statements` で Collector が起動に失敗する。
+
 ---
 
 ## File Structure
@@ -551,8 +581,8 @@ ANSI エスケープの除去、severity の判定、サービス名の設定、
             error_mode: ignore
             log_statements:
               # WARN 以上は優先度 100 を付与し、サンプリング率に関わらず必ず通す
-              - set(attributes["sample_priority"], 100)
-                  where severity_number >= SEVERITY_NUMBER_WARN
+              - set(log.attributes["sample_priority"], 100)
+                  where log.severity_number >= SEVERITY_NUMBER_WARN
           transform/service_name:
             error_mode: ignore
             log_statements:
@@ -577,27 +607,27 @@ ANSI エスケープの除去、severity の判定、サービス名の設定、
             log_statements:
               # zerolog の ConsoleWriter 形式は ANSI カラーエスケープを含む。
               # 先に除去しないと後続の正規表現がレベル表記に一致しない。
-              - replace_pattern(body, "\\x1b\\[[0-9;]*m", "") where IsString(body)
+              - replace_pattern(log.body, "\\x1b\\[[0-9;]*m", "") where IsString(log.body)
               # filelog receiver の container operator は本文を文字列のまま body に
               # 入れるため、JSON ログも自動ではパースされない。明示的にパースして
               # map に変換することで、level の判定と Mackerel 画面での属性検索が効く。
-              - set(body, ParseJSON(body))
-                  where IsString(body) and IsMatch(body, "^\\s*\\{")
+              - set(log.body, ParseJSON(log.body))
+                  where IsString(log.body) and IsMatch(log.body, "^\\s*\\{")
               # JSON ログは level フィールドから判定する
-              - set(severity_number, SEVERITY_NUMBER_ERROR)
-                  where not IsString(body) and body["level"] == "error"
-              - set(severity_number, SEVERITY_NUMBER_WARN)
-                  where not IsString(body) and body["level"] == "warn"
-              - set(severity_number, SEVERITY_NUMBER_INFO)
-                  where not IsString(body) and body["level"] == "info"
+              - set(log.severity_number, SEVERITY_NUMBER_ERROR)
+                  where not IsString(log.body) and log.body["level"] == "error"
+              - set(log.severity_number, SEVERITY_NUMBER_WARN)
+                  where not IsString(log.body) and log.body["level"] == "warn"
+              - set(log.severity_number, SEVERITY_NUMBER_INFO)
+                  where not IsString(log.body) and log.body["level"] == "info"
               # テキストログは本文から推定する。zerolog の ERR / WRN 表記にも対応する
-              - set(severity_number, SEVERITY_NUMBER_ERROR)
-                  where IsString(body)
-                    and IsMatch(body, "(?i)\\b(err|error|fatal|panic)\\b")
-              - set(severity_number, SEVERITY_NUMBER_WARN)
-                  where IsString(body)
-                    and severity_number == SEVERITY_NUMBER_UNSPECIFIED
-                    and IsMatch(body, "(?i)\\b(wrn|warn|warning)\\b")
+              - set(log.severity_number, SEVERITY_NUMBER_ERROR)
+                  where IsString(log.body)
+                    and IsMatch(log.body, "(?i)\\b(err|error|fatal|panic)\\b")
+              - set(log.severity_number, SEVERITY_NUMBER_WARN)
+                  where IsString(log.body)
+                    and log.severity_number == SEVERITY_NUMBER_UNSPECIFIED
+                    and IsMatch(log.body, "(?i)\\b(wrn|warn|warning)\\b")
         service:
           pipelines:
             logs:

--- a/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
@@ -1,0 +1,370 @@
+# Mackerel ログ送信基盤の設計
+
+## 背景と目的
+
+Mackerel は 2026 年 7 月 16 日にログ機能をオープン β として公開した。
+本設計は、lily クラスタのログを Mackerel に送る基盤を用意し、既存の Grafana Loki を将来的に縮小または廃止できるかを評価することを目的とする。
+
+評価対象としたい点は次の二つである。
+
+- **保管先としての代替可能性**：Loki が担っている保管と検索を Mackerel が肩代わりできるか
+- **運用コスト**：正式リリース後の従量課金が、自宅クラスタの運用費として許容できる水準に収まるか
+
+Mackerel のログ機能には、本設計の時点で次の制約がある。
+
+- **保持期間**：30 日（Loki の現行設定と同じ）
+- **料金**：β 期間中は無料、正式リリース後は 70 円/GB（税別）。課金対象は送信量のみで、保管とクエリは無料
+- **ログ監視**：未実装。ログを起点にアラートを上げる機能はロードマップ段階にある
+- **データ保持の保証**：β 期間中は保証されない
+
+ログ監視が未実装であるため、本設計では Mackerel の既存の監視ルール（Terraform で管理している `mackerel_monitor_*`）との連携を扱わない。
+
+## 現状
+
+lily クラスタのログは Grafana Alloy が収集し、Loki に保管している。
+
+```
+Pod ログ ─┐
+          ├─> Alloy ──(HTTP push)──> Loki ──(LogQL)──> Grafana
+journald ─┘   DaemonSet              StatefulSet
+              1 Pod                  3 Pod + 10Gi PV
+```
+
+`k8s/system/opentelemetry-collector`、`k8s/system/fluent-bit`、`k8s/system/openobserve-collector` の各ディレクトリは ArgoCD の ApplicationSet に登録されておらず、どのクラスタにもデプロイされていない。
+このうち opentelemetry-collector の既存設定は `mode: deployment` でありながら `logsCollection` preset を有効にしている。
+この preset は各ノードのログファイルを読む filelog receiver を追加するもので、DaemonSet を前提とする。
+exporter が未設定のため実害は出ていないが、この設定をそのまま流用することはできない。
+
+Mackerel 自体はメトリクス監視で既に運用している。
+container-agent の sidecar 注入、mackerel-operator、Terraform による監視ルールの管理が稼働しており、API キーは 1Password Connect の `OnePasswordItem` で配布している。
+
+## 実測
+
+設計判断の根拠として、Loki の受信量を実測した。
+
+### 全体の流量
+
+`loki_distributor_bytes_received_total` を Loki の 22.18 日分の稼働から取得した。
+
+| 項目 | 値 |
+| --- | --- |
+| 累計受信量 | 32.69 GB |
+| 累計行数 | 6,113 万行 |
+| 1 行あたり平均 | 535 bytes |
+| 日次 | 1.474 GB/日 |
+| 月次 | 44.8 GB/月 |
+| 全量送信時の月額（70 円/GB） | 3,136 円 |
+
+### namespace 別の内訳
+
+直近 1 時間の LogQL クエリによる集計を示す（この時間帯は平均より流量が多く、日次換算で 2.969 GB/日に相当する）。
+
+| namespace | GB/日 | 占有率 |
+| --- | --- | --- |
+| nebula | 1.842 | 62.1% |
+| traefik | 0.945 | 31.8% |
+| kube-system | 0.068 | 2.3% |
+| その他 | 0.114 | 3.8% |
+
+上位二つで全体の 93.9% を占める。
+
+以降の表は別のタイミングで取得したため、合計値が本表と僅かに異なる。
+
+### 発生源の内訳
+
+nebula と traefik の中身をさらに分解した。
+
+| 対象 | GB/日 | 備考 |
+| --- | --- | --- |
+| nebula の DBG | 1.724 | namespace 内の 94.6%。SQL クエリ全文を出力している |
+| nebula の INF | 0.095 | |
+| nebula の WRN と ERR | 0.003 | namespace 内の 0.16% |
+| traefik の 2xx | 0.885 | namespace 内の 92.8% |
+| traefik の 4xx | 0.054 | |
+| traefik の 5xx | 0.000 | 計測期間中は発生なし |
+
+クラスタ全体の約 88% が、デバッグログと正常時のアクセスログで占められている。
+
+nebula backend の Deployment にはログレベルの設定が存在せず、アプリケーションの既定値である DEBUG のまま稼働している。
+
+traefik のアクセスログは 1 レコードあたり平均 3,554 bytes に達する。
+`--accesslog.fields.headers.defaultmode=keep` により、リクエスト、レスポンス、オリジン応答の三系統の HTTP ヘッダーがすべて記録されているためである。
+
+| カテゴリ | bytes/rec | 占有率 |
+| --- | --- | --- |
+| `request_*`（リクエストヘッダー） | 1,094 | 31.2% |
+| コアフィールド（ヘッダー以外） | 927 | 26.5% |
+| `origin_*`（オリジン応答ヘッダー） | 685 | 19.6% |
+| `downstream_*` のうち固定セキュリティヘッダー | 454 | 13.0% |
+| `downstream_*` のその他 | 338 | 9.7% |
+
+ヘッダーが全体の 73.5% を占める。
+`origin_*` は `downstream_*` とほぼ同一の値を持つ重複であり、固定セキュリティヘッダー（`Strict-Transport-Security`、`Content-Security-Policy`、`X-Frame-Options` など）は毎リクエスト同じ値を返すため情報量がない。
+
+## アーキテクチャ
+
+OpenTelemetry Collector を新設し、Mackerel への送信を担わせる。
+Alloy と Loki の既存経路は評価期間中そのまま並走させる。
+
+```
+┌─ lily クラスタ ────────────────────────────────────────────┐
+│                                                            │
+│  /var/log/pods ──> otel-agent (DaemonSet)                  │
+│                     ├ filelog receiver                     │
+│                     ├ k8sattributes                        │
+│                     ├ transform (ANSI 除去, severity 付与) │
+│                     ├ filter    (オプトアウト判定)         │
+│                     ├ transform (サービス名, 優先度付与)   │
+│                     ├ probabilistic_sampler                │──> Mackerel
+│                     └ batch                                │
+│                        ↑ OTLP :4317                        │
+│  journald ──> Alloy ───┘                                   │
+│                                                            │
+│  k8s events ──> otel-cluster (Deployment ×1)               │──> Mackerel
+│                                                            │
+│  ※ Alloy → Loki の既存経路は変更せず並走                   │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Collector を二リリースに分ける理由
+
+Helm chart の preset は、対応する動作モードが異なる。
+`logsCollection` は DaemonSet を前提とし、`kubernetesEvents` は Deployment または StatefulSet を前提とする。
+両方を使うには Helm リリースを二つ立てる必要があり、これは chart が想定した使い方である。
+
+### イメージ
+
+既存の設定と同じ `otel/opentelemetry-collector-k8s` を使う。
+本設計が必要とするコンポーネントは、このディストリビューションにすべて含まれている。
+
+- `filelogreceiver`、`k8seventsreceiver`、`k8sobjectsreceiver`、`otlpreceiver`
+- `k8sattributesprocessor`、`transformprocessor`、`filterprocessor`、`probabilisticsamplerprocessor`、`batchprocessor`
+- `otlphttpexporter`
+
+より重量級の contrib イメージに切り替える必要はない。
+
+### journald を Alloy 経由にする理由
+
+OpenTelemetry の journald receiver は `journalctl` バイナリを実行する実装であり、ジャーナルを読むロジックを自前で持たない。
+公式イメージ `otel/opentelemetry-collector-k8s` は distroless であり、`sh` すら含まない。
+このイメージのままでは journald 収集は動作しない。
+
+一方 Alloy の `loki.source.journal` は自前実装であり、`journalctl` に依存せず既に稼働している。
+そこで journald の読み取りだけを Alloy に任せ、OTLP で Collector に渡す。
+
+この構成において、Alloy は読み取り役に留まる。
+Mackerel への送信、severity の付与、オプトアウト判定、サンプリングはすべて Collector 側で行い、Mackerel の API キーを持つのも Collector だけである。
+
+Pod ログを Alloy 経由にしない理由は、Loki のラベル形式にある。
+`loki.source.kubernetes` が付けるラベルは `namespace` や `pod_name` であり、Mackerel が前提とする OpenTelemetry のセマンティック規約（`k8s.namespace.name`、`k8s.pod.name`）と食い違う。
+Pod ログは Collector が filelog receiver で直接読むことで、規約通りの属性が付く。
+journald のラベルは `unit` 程度であり、そもそも Kubernetes の規約の対象外であるため、この問題は起きない。
+
+Loki を廃止した後も Alloy は DaemonSet 1 Pod として残るが、役割は journald の読み取りだけに縮小する。
+Loki の廃止によって回収できるのは 3 Pod と 10Gi のローカル PV であり、この縮小は Alloy を残しても得られる。
+
+## リソース構成
+
+```
+k8s/system/opentelemetry-collector/
+├── kustomization.yaml          # Helm リリース 2 つ（agent, cluster）
+└── resources/
+    ├── namespace.yaml
+    └── secret.yaml             # OnePasswordItem で Mackerel API キーを配布
+```
+
+ApplicationSet への登録が必要である。
+`k8s/system/argo-cd/resources/application-set-lily.yaml` に project `system` として追加しなければ、ディレクトリを作ってもデプロイされない。
+
+## ログ属性の設計
+
+Mackerel のログ検索は `service.namespace` と `service.name` の組で対象サービスを選ぶ流れになっている。
+この二つの属性の設計が、そのまま画面での探しやすさを決める。
+
+| 対象 | `service.namespace` | `service.name` |
+| --- | --- | --- |
+| Pod ログ | Kubernetes の namespace（`nebula`） | ワークロード名（`backend`） |
+| journald | `lily` | `systemd` |
+| Kubernetes Events | `lily` | `kubernetes-events` |
+
+ワークロード名は `k8sattributes` processor が抽出する `k8s.deployment.name`、`k8s.daemonset.name`、`k8s.statefulset.name` のいずれかから決める。
+いずれも取得できない場合は `k8s.pod.name` にフォールバックする。
+
+## severity の判定
+
+Pod の標準出力ログは、filelog receiver が読んだ時点では本文が文字列として Body に入るだけであり、`severity_number` は `UNSPECIFIED` のままである。
+サンプリングを重要度で分けるには、送信前に severity を判定する工程が必要になる。
+
+nebula のログは zerolog の ConsoleWriter 形式であり、レベル表記に ANSI カラーエスケープが混入している。
+
+```
+\x1b[2mAug  1 07:54:08.005\x1b[0m \x1b[92mINF\x1b[0m producer: Producer job counts
+```
+
+このため、ANSI エスケープの除去を先に行う。
+順序を誤ると、後続の正規表現がレベル表記に一致しない。
+
+```
+1. ANSI エスケープの除去
+   replace_pattern(body, "\x1b\[[0-9;]*m", "") where IsString(body)
+
+2. JSON ログなら level フィールドから判定
+   set(severity_number, SEVERITY_NUMBER_ERROR) where body["level"] == "error"
+
+3. テキストログは本文から推定（zerolog の ERR / WRN 表記にも対応する）
+   set(severity_number, SEVERITY_NUMBER_ERROR)
+     where IsString(body) and IsMatch(body, "(?i)\b(err|error|fatal|panic)\b")
+```
+
+判定できなかったログは `UNSPECIFIED` のままとし、サンプリングの対象に含める。
+判定漏れしたエラーが間引かれる可能性を負うが、多弁なアプリケーションのノイズを抑えることを優先する。
+
+## オプトアウト
+
+Pod のアノテーションで除外を指定する。
+Deployment の `spec.template.metadata.annotations` に書けば Pod に伝播するため、ワークロード単位の指定として機能する。
+
+```yaml
+metadata:
+  annotations:
+    mackerel.io/logs: "false"
+```
+
+既存の設定で `kubernetesAttributes` preset の `extractAllPodAnnotations: true` が有効であるため、Pod のアノテーションは `k8s.pod.annotation.mackerel.io/logs` としてリソース属性に載る。
+filter processor の OTTL 式からそのまま参照できる。
+
+```yaml
+filter/optout:
+  logs:
+    log_record:
+      - 'resource.attributes["k8s.pod.annotation.mackerel.io/logs"] == "false"'
+```
+
+## サンプリング
+
+`probabilistic_sampler` は既定で trace ID を参照する。
+Kubernetes の標準出力ログに trace ID は存在せず、既定の `fail_closed: true` と組み合わさると全ログが破棄される。
+`fail_closed: false` にすればサンプリングが一切効かなくなる。
+どちらも意図と異なるため、`sampling_priority` によって明示的に制御する。
+
+WARN 以上には優先度 100 を付与して無条件に通し、それ未満のみを確率的に間引く。
+
+```yaml
+transform/priority:
+  log_statements:
+    - set(attributes["sample_priority"], 100)
+        where severity_number >= SEVERITY_NUMBER_WARN
+
+probabilistic_sampler:
+  sampling_percentage: 100    # 初期値。実測後に調整する
+  sampling_priority: sample_priority
+```
+
+初期値を 100% とする理由は、後述の発生源の是正によって送信量が十分小さくなるためである。
+
+ただし率を 100% 未満に下げる際は、`sampling_percentage` の変更だけでは足りない。
+優先度を持たないログについて、ハッシュの種を明示する必要がある。
+
+```yaml
+probabilistic_sampler:
+  mode: hash_seed
+  sampling_percentage: 20
+  attribute_source: record
+  from_attribute: <種となる属性>
+  sampling_priority: sample_priority
+```
+
+種の選び方によってサンプリングの意味が変わる。
+
+- **`k8s.pod.uid`**：Pod 単位で採否が決まる。採用された Pod のログは全量残るため前後関係が保たれるが、まったく見えない Pod が生じる
+- **transform で付与した UUID**：行単位で間引く。全 Pod から満遍なく残るが、スタックトレースが途中で欠ける
+
+この選択は実際の流量を見てから判断する。
+
+サンプリングはサーバの負荷を下げない。
+パイプラインの終盤に位置するため、読み取り、パース、severity 付与という処理は全ログに対して既に走っている。
+減るのは Mackerel への送信量、すなわち課金額だけである。
+
+## 発生源の是正
+
+送信量の設計としては、サンプリング率より発生源の見直しのほうが効果が大きい。
+
+### nebula のログレベル
+
+backend と worker の ConfigMap に `LOG_LEVEL=info` を追加する。
+これにより DBG のログが止まり、1.724 GB/日が削減される。
+Loki のディスク消費と Pod の CPU も同時に軽くなる。
+
+### traefik のヘッダー
+
+`defaultmode` を反転し、必要なヘッダーだけを明示的に残す。
+
+```diff
+- --accesslog.fields.headers.defaultmode=keep
+- --accesslog.fields.headers.names.Authorization=redact
+- --accesslog.fields.headers.names.Cookie=redact
+- --accesslog.fields.headers.names.X-Authentik-Jwt=redact
++ --accesslog.fields.headers.defaultmode=drop
++ --accesslog.fields.headers.names.User-Agent=keep
++ --accesslog.fields.headers.names.Referer=keep
++ --accesslog.fields.headers.names.Origin=keep
++ --accesslog.fields.headers.names.X-Real-Ip=keep
++ --accesslog.fields.headers.names.Accept-Language=keep
++ --accesslog.fields.headers.names.Sec-Ch-Ua=keep
++ --accesslog.fields.headers.names.Sec-Ch-Ua-Mobile=keep
++ --accesslog.fields.headers.names.Sec-Ch-Ua-Platform=keep
++ --accesslog.fields.headers.names.Sec-Fetch-Site=keep
++ --accesslog.fields.headers.names.Sec-Fetch-Mode=keep
++ --accesslog.fields.headers.names.Sec-Fetch-Dest=keep
++ --accesslog.fields.headers.names.Cf-Connecting-Ip=keep
++ --accesslog.fields.headers.names.Cf-Ray=keep
++ --accesslog.fields.headers.names.Cf-Visitor=keep
++ --accesslog.fields.headers.names.Cf-Ipcountry=keep
++ --accesslog.fields.headers.names.Cf-Ipcity=keep
+```
+
+1 レコードは 3,554 bytes から約 1,422 bytes に減り、traefik の流量は 0.945 GB/日から約 0.38 GB/日になる。
+
+Cloudflare が付与するヘッダーのうち、緯度経度（`Cf-Iplatitude`、`Cf-Iplongitude`）、郵便番号（`Cf-Postal-Code`）、タイムゾーン（`Cf-Timezone`）は keep しない。
+アクセスの大半が自宅からである以上、これらを送ると生活圏の座標が SaaS 側に 30 日間保持される。
+国と都市のレベル（`Cf-Ipcountry`、`Cf-Ipcity`）であれば分析用途を満たしつつ、粒度は穏当に収まる。
+
+`defaultmode=drop` にすると `Authorization` と `Cookie` の `redact` 指定は不要になる。
+今後クラスタに新しい機密ヘッダーが増えても、明示的に keep しない限りログに載らない。
+redact の指定漏れという事故が構造的に起きなくなる。
+
+### 是正の効果
+
+| 段階 | クラスタ全体 | 月額（全量送信時） |
+| --- | --- | --- |
+| 現状 | 2.97 GB/日 | 3,136 円 |
+| nebula 是正後 | 1.25 GB/日 | 1,320 円 |
+| traefik 是正後 | 0.68 GB/日 | 約 720 円 |
+
+サンプリングを 100% のままでも、正式リリース後の月額は約 720 円に収まる。
+
+## 実施順序
+
+1. 発生源の是正（nebula の `LOG_LEVEL`、traefik のヘッダー）
+2. Collector の追加と ApplicationSet への登録
+3. Alloy から journald を OTLP で橋渡し
+4. Mackerel の画面で実データを確認し、サンプリング率を判断
+
+手順 1 は Mackerel 導入と独立に効果があり、Loki のディスクと Pod の CPU を軽くする。
+手順 2 の前に実施することで、Collector が扱う流量を最初から小さくできる。
+
+## 検証
+
+- Collector の Pod が起動し、`otelcol_exporter_sent_log_records_total` が増加すること
+- Mackerel のログ画面で、`service.namespace` ごとにログが分類されて表示されること
+- WARN 以上のログが Mackerel に届いていること
+- `mackerel.io/logs: "false"` を付けたワークロードのログが Mackerel に届かないこと
+- journald のログが Mackerel に届いていること
+- 是正後の Loki 受信量が想定通り減っていること
+
+## 未決事項とリスク
+
+- **nebula アプリケーションが `LOG_LEVEL` 環境変数を参照するかは未確認である**。参照しない場合は、アプリケーション側の設定方法を調べ直す必要がある。
+- **ANSI エスケープ除去の正規表現は実データでの動作確認が必要である**。OTTL の `replace_pattern` は RE2 を使うため、`\x1b` の記法が期待通り解釈されるかを実際のログで確かめる。
+- **β 期間中はデータ保持が保証されない**。評価期間中に Loki を縮小しない理由がこれにあたる。
+- **ログ監視が未実装であるため、Loki 廃止の判断は保留する**。Loki 側でログを起点にしたアラートを運用している場合、Mackerel だけでは代替できない。

--- a/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
@@ -300,7 +300,7 @@ filter processor の OTTL 式からそのまま参照できる。
 filter/optout:
   logs:
     log_record:
-      - 'resource.attributes["k8s.pod.annotation.mackerel.io/logs"] == "false"'
+      - 'resource.attributes["mackerel.io/logs"] == "false"'
 ```
 
 ## サンプリング

--- a/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
@@ -176,6 +176,69 @@ k8s/system/opentelemetry-collector/
 ApplicationSet への登録が必要である。
 `k8s/system/argo-cd/resources/application-set-lily.yaml` に project `system` として追加しなければ、ディレクトリを作ってもデプロイされない。
 
+## セキュリティコンテキスト
+
+ログ収集の DaemonSet を root で動かす必要はない。
+ノード上のファイルの権限を実測した結果を示す。
+
+| 対象 | パーミッション | 読み取りの条件 |
+| --- | --- | --- |
+| `/var/log/pods/` の各階層 | `drwxr-xr-x root root` | other に `x` があり通過できる |
+| `/var/log/pods/**/0.log` | `-rw-r----- root root` | root グループに属していれば読める |
+| `/var/log/journal/*/*.journal` | `-rw-r-----+ root 983` | gid 983（systemd-journal）に属していれば読める |
+
+`supplementalGroups` で必要なグループだけを付与すれば、非 root で読み取れる。
+現行の Alloy が uid 0 で動作しているのは、Helm chart が securityContext を設定せず、イメージの既定値がそのまま出ているためである。
+
+Collector には既存の慣行（`traefik/whoami`、`mackerel-container-agent-sidecar-injector`）と同じ形を適用する。
+
+otel-agent は Pod ログを読むため、root グループへの所属だけを追加する。
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  # /var/log/pods 配下のログファイルが 0640 root:root であるため、
+  # 読み取りには root グループへの所属が必要になる
+  supplementalGroups: [0]
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+```
+
+otel-cluster は Kubernetes API のみを参照し、ホストのファイルを読まない。
+`supplementalGroups` は付与しない。
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+```
+
+`readOnlyRootFilesystem: true` により、`logsCollection` preset の `storeCheckpoints` は使えない。
+このオプションは読み取り位置を `/var/lib/otelcol` に保存するもので、chart のドキュメントにも実行ユーザーを root に変更すると記載がある。
+既定値の `false` のまま進める。
+Pod 再起動時に読み取り位置を失う代償はあるが、評価フェーズでは非 root を維持することを優先する。
+
+稼働中の Alloy には手を入れない。
+journald の読み取りに必要な gid 983 はノードの `/etc/group` に依存する値であり、マニフェストにノード固有の数値を埋め込むことになる。
+Collector 側で非 root の動作を確認してから、別途適用を判断する。
+
 ## ログ属性の設計
 
 Mackerel のログ検索は `service.namespace` と `service.name` の組で対象サービスを選ぶ流れになっている。
@@ -355,6 +418,8 @@ redact の指定漏れという事故が構造的に起きなくなる。
 
 ## 検証
 
+- Collector の Pod が非 root（uid 10001）で起動し、`/var/log/pods` 配下のログを読めていること
+- kube-linter が Collector のマニフェストに対して特権関連の指摘を出さないこと
 - Collector の Pod が起動し、`otelcol_exporter_sent_log_records_total` が増加すること
 - Mackerel のログ画面で、`service.namespace` ごとにログが分類されて表示されること
 - WARN 以上のログが Mackerel に届いていること
@@ -367,4 +432,32 @@ redact の指定漏れという事故が構造的に起きなくなる。
 - **nebula アプリケーションが `LOG_LEVEL` 環境変数を参照するかは未確認である**。参照しない場合は、アプリケーション側の設定方法を調べ直す必要がある。
 - **ANSI エスケープ除去の正規表現は実データでの動作確認が必要である**。OTTL の `replace_pattern` は RE2 を使うため、`\x1b` の記法が期待通り解釈されるかを実際のログで確かめる。
 - **β 期間中はデータ保持が保証されない**。評価期間中に Loki を縮小しない理由がこれにあたる。
+- **`supplementalGroups: [0]` で実際に Pod ログを読めるかは実機で確認する**。ファイルの権限からは読めると判断できるが、非 root での動作は実際に Collector を起動して確かめる。
 - **ログ監視が未実装であるため、Loki 廃止の判断は保留する**。Loki 側でログを起点にしたアラートを運用している場合、Mackerel だけでは代替できない。
+
+## 採用しなかった選択肢
+
+journald の収集について、Alloy 以外の手段も検討した。
+イメージサイズは実測値である。
+
+| 方式 | journald の読み方 | イメージ | 公式イメージで動くか |
+| --- | --- | --- | --- |
+| Alloy（採用） | `loki.source.journal`（libsystemd） | 165 MB | 稼働中 |
+| Fluent Bit | `systemd` input（libsystemd） | 50 MB | そのまま動く |
+| カスタム Collector | `journald` receiver（`journalctl` を起動） | 89 MB | 自前ビルドが必要 |
+| Vector | `journald` source | 92 MB | そのまま動く |
+
+技術的には Fluent Bit が最も軽く、libsystemd を直接呼ぶ点でも筋が良い。
+OpenTelemetry の `journald` receiver は `journalctl` をサブプロセスとして起動し、その出力をパースする実装であり、テキストへの整形と再パースが挟まる。
+
+それでも Alloy を採用したのは、評価期間中は Loki のために Alloy がどのみち稼働しているためである。
+この期間に限れば、Alloy への追加実装は `config.alloy` の数行で済み、新しい DaemonSet を増やさない。
+Fluent Bit を今導入すると、Alloy と Fluent Bit が同じジャーナルを二重に読む期間が生じる。
+
+Loki を廃止する段階では、Alloy を Fluent Bit に置き換える余地がある。
+イメージは 165 MB から 50 MB に減り、Loki 系ツールへの依存を断てる。
+`db` パラメータによるカーソル永続化も利点になる。
+
+カスタムイメージ案は OpenTelemetry 公式が案内している方法だが、このリポジトリでは採用しない。
+CI に Trivy が組み込まれており、distroless から Debian ベースに移ると OS パッケージ由来の CVE が検出対象に加わる。
+`.trivyignore.yaml` の保守と、ベースイメージの追従を自前で背負うことになる。

--- a/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
@@ -293,8 +293,10 @@ metadata:
     mackerel.io/logs: "false"
 ```
 
-既存の設定で `kubernetesAttributes` preset の `extractAllPodAnnotations: true` が有効であるため、Pod のアノテーションは `k8s.pod.annotation.mackerel.io/logs` としてリソース属性に載る。
-filter processor の OTTL 式からそのまま参照できる。
+既存の設定で `kubernetesAttributes` preset の `extractAllPodAnnotations: true` が有効であるため、Pod のアノテーションはリソース属性に載る。
+この preset は `tag_name: $$1` と `key_regex: (.*)` を生成するため、属性名はアノテーションのキーそのものになる。
+`k8s.pod.annotation.` の接頭辞は付かない。
+OTTL では存在しない属性との比較が nil 比較になり false を返すだけであり、名前を誤ると警告もエラーも出ないまま静かに機能しなくなる。
 
 ```yaml
 filter/optout:
@@ -429,10 +431,13 @@ redact の指定漏れという事故が構造的に起きなくなる。
 
 ## 未決事項とリスク
 
-- **nebula アプリケーションが `LOG_LEVEL` 環境変数を参照するかは未確認である**。参照しない場合は、アプリケーション側の設定方法を調べ直す必要がある。
-- **ANSI エスケープ除去の正規表現は実データでの動作確認が必要である**。OTTL の `replace_pattern` は RE2 を使うため、`\x1b` の記法が期待通り解釈されるかを実際のログで確かめる。
+- ~~**nebula アプリケーションが `LOG_LEVEL` 環境変数を参照するかは未確認である**~~
+  → 解消。`backend/util/logger/logger.go` に `env:"LOG_LEVEL" envDefault:"debug"` と定義されていることをソースで確認した。既定値が DEBUG だったことも裏付けられた。
+- **ANSI エスケープ除去の正規表現は実データでの動作確認が必要である**。OTTL の `replace_pattern` は RE2 を使うため、`\x1b` の記法が期待通り解釈されるかを実際のログで確かめる。設定として妥当であることは `otelcol validate` で確認済みだが、実際に除去されるかは未検証である。
 - **β 期間中はデータ保持が保証されない**。評価期間中に Loki を縮小しない理由がこれにあたる。
 - **`supplementalGroups: [0]` で実際に Pod ログを読めるかは実機で確認する**。ファイルの権限からは読めると判断できるが、非 root での動作は実際に Collector を起動して確かめる。
+- **`mode: daemonset` は hostPort をノード IP に露出させる**。この Collector は Mackerel API キーを持つため、認証なしの受信口を LAN に開けない。`ports` で jaeger / zipkin / otlp-http を無効化し、`otlp` は `hostPort: 0` にした。Alloy からの接続は Service（`internalTrafficPolicy: Local`）経由で足りる。ポート宣言を消してもプロセスは Pod IP で listen したままである点は残る（クラスタ内からは到達可能）。
+- **`logsCollection` preset の `includeCollectorLogs: false` は自身のリリース分しか除外しない**。`otel-cluster` を追加した際に、そのログが Mackerel に送られる状態になった。`filelog.exclude` を `otel-*` パターンで上書きして両方を除外している。この上書きはリリース名の命名規則に暗黙的に依存する。
 - **ログ監視が未実装であるため、Loki 廃止の判断は保留する**。Loki 側でログを起点にしたアラートを運用している場合、Mackerel だけでは代替できない。
 
 ## 採用しなかった選択肢

--- a/k8s/apps/grafana-alloy/config/config.alloy
+++ b/k8s/apps/grafana-alloy/config/config.alloy
@@ -58,7 +58,31 @@ loki.relabel "node_systemd_journal" {
 }
 
 loki.source.journal "node_systemd_journal" {
-	forward_to    = [loki.write.default.receiver]
+	forward_to    = [
+		loki.write.default.receiver,
+		otelcol.receiver.loki.journald.receiver,
+	]
 	relabel_rules = loki.relabel.node_systemd_journal.rules
 	labels        = {component = "loki.source.journal"}
+}
+
+// journald のログを OpenTelemetry Collector に転送する。
+// Collector の公式イメージは distroless で journalctl を含まないため、
+// journald の読み取りだけを Alloy が担い、Mackerel への送信は Collector が行う。
+otelcol.receiver.loki "journald" {
+	output {
+		logs = [otelcol.exporter.otlp.collector.input]
+	}
+}
+
+otelcol.exporter.otlp "collector" {
+	client {
+		// otel-agent の DaemonSet 名は *-agent だが、Service 名には付かない
+		// （chart のヘルパーが agent/standalone で Service 名を分けていない）。
+		endpoint = "otel-agent-opentelemetry-collector.opentelemetry-collector:4317"
+
+		tls {
+			insecure = true
+		}
+	}
 }

--- a/k8s/apps/nebula/kustomization.yaml
+++ b/k8s/apps/nebula/kustomization.yaml
@@ -98,3 +98,5 @@ configMapGenerator:
       - INSTAGRAM_BASE_URL=http://instagram:8085
       - YTDLP_BASE_URL=http://ytdlp:8086
       - FFMPEG_BASE_URL=http://ffmpeg:8087
+      # DEBUG では SQL クエリの全文が出力され、クラスタ全体のログ量の 58% を占めていた
+      - LOG_LEVEL=info

--- a/k8s/system/argo-cd/resources/application-set-lily.yaml
+++ b/k8s/system/argo-cd/resources/application-set-lily.yaml
@@ -252,6 +252,10 @@ spec:
             namespace: mackerel-operator
             path: k8s/system/mackerel-operator
             project: system
+          - name: opentelemetry-collector
+            namespace: opentelemetry-collector
+            path: k8s/system/opentelemetry-collector
+            project: system
 
   template:
     metadata:

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -32,10 +32,18 @@ helmCharts:
             error_mode: ignore
             logs:
               log_record:
-                - 'resource.attributes["k8s.pod.annotation.mackerel.io/logs"] == "false"'
+                # k8sattributes preset は tag_name: $$1 / key_regex: (.*) を生成するため、
+                # 属性名はアノテーションのキーそのものになる。k8s.pod.annotation. の
+                # 接頭辞は付かない。誤ると nil 比較になり静かに機能しなくなる。
+                - 'resource.attributes["mackerel.io/logs"] == "false"'
           probabilistic_sampler:
             # 初期値は 100%。発生源の是正により全量でも月 720 円に収まるため、
             # まず全量送信して実データを確認する。
+            #
+            # 100 未満に下げるときは attribute_source と from_attribute の指定が
+            # 必須になる。Pod ログには trace ID がなく、既定の traceID を種にすると
+            # WARN 未満が指定率ではなく 0% になる。種の選び方は設計文書の
+            # 「サンプリング」節を参照する。
             sampling_percentage: 100
             sampling_priority: sample_priority
           transform/journald_service_name:
@@ -96,6 +104,11 @@ helmCharts:
                     and log.severity_number == SEVERITY_NUMBER_UNSPECIFIED
                     and IsMatch(log.body, "(?i)\\b(wrn|warn|warning)\\b")
         receivers:
+          filelog:
+            # preset の includeCollectorLogs は otel-agent 自身の分しか除外しない。
+            # otel-cluster のログも Mackerel に送られてしまうため、両方を除外する。
+            exclude:
+              - /var/log/pods/opentelemetry-collector_otel-*_*/opentelemetry-collector/*.log
           # Alloy から journald ログを OTLP で受け取る。journalctl を実行できない
           # distroless イメージの代わりに、libsystemd を直接呼ぶ Alloy に読み取りを任せる。
           otlp:
@@ -159,6 +172,22 @@ helmCharts:
         # 読み取りには root グループへの所属が必要になる
         supplementalGroups:
           - 0
+      ports:
+        # DaemonSet では hostPort がノード IP に露出する。この Collector は
+        # Mackerel API キーを持つため、認証なしの受信口を LAN に開けない。
+        # Alloy からの接続は Service (internalTrafficPolicy: Local) 経由で足りる。
+        jaeger-compact:
+          enabled: false
+        jaeger-grpc:
+          enabled: false
+        jaeger-thrift:
+          enabled: false
+        otlp:
+          hostPort: 0
+        otlp-http:
+          enabled: false
+        zipkin:
+          enabled: false
       presets:
         kubernetesAttributes:
           enabled: true

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -59,6 +59,11 @@ helmCharts:
               # zerolog の ConsoleWriter 形式は ANSI カラーエスケープを含む。
               # 先に除去しないと後続の正規表現がレベル表記に一致しない。
               - replace_pattern(body, "\\x1b\\[[0-9;]*m", "") where IsString(body)
+              # filelog receiver の container operator は本文を文字列のまま body に
+              # 入れるため、JSON ログも自動ではパースされない。明示的にパースして
+              # map に変換することで、level の判定と Mackerel 画面での属性検索が効く。
+              - set(body, ParseJSON(body))
+                  where IsString(body) and IsMatch(body, "^\\s*\\{")
               # JSON ログは level フィールドから判定する
               - set(severity_number, SEVERITY_NUMBER_ERROR)
                   where not IsString(body) and body["level"] == "error"

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -12,10 +12,15 @@ helmCharts:
     valuesInline:
       config:
         exporters:
-          debug:
-            # 変換結果を目視で確認するため detailed にする。
-            # Task 5 で Mackerel exporter に切り替える際に削除する。
-            verbosity: detailed
+          otlphttp/mackerel:
+            endpoint: https://otlp-vaxila.mackerelio.com
+            headers:
+              Mackerel-Api-Key: ${env:MACKEREL_APIKEY}
+            sending_queue:
+              batch:
+                # Mackerel が受け付ける 1 リクエストの上限
+                max_size: 3500000
+                sizer: bytes
         processors:
           # 除外対象を先に落とし、後続の変換コストを減らす
           filter/optout:
@@ -83,7 +88,7 @@ helmCharts:
           pipelines:
             logs:
               exporters:
-                - debug
+                - otlphttp/mackerel
               processors:
                 # Helm の values マージでは配列は置換されるため、chart が既定で
                 # 入れる memory_limiter と batch を明示的に書き戻す必要がある。
@@ -95,6 +100,12 @@ helmCharts:
                 - transform/sampling
                 - probabilistic_sampler
                 - batch
+      extraEnvs:
+        - name: MACKEREL_APIKEY
+          valueFrom:
+            secretKeyRef:
+              name: mackerel-api-key
+              key: apiKey
       image:
         repository: otel/opentelemetry-collector-k8s
       mode: daemonset

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -146,6 +146,78 @@ helmCharts:
         privileged: false
         readOnlyRootFilesystem: true
 
+  - name: opentelemetry-collector
+    releaseName: otel-cluster
+    namespace: opentelemetry-collector
+    version: 0.159.0
+    repo: https://open-telemetry.github.io/opentelemetry-helm-charts
+    valuesInline:
+      config:
+        exporters:
+          # kubernetesEvents preset は logs パイプラインのみを使うが、chart は
+          # metrics/traces のパイプラインも既定で作り、debug exporter に出力する。
+          # このリリースはイベント収集専用でメトリクス・トレースは扱わないため、
+          # 収集結果を捨てる。Helm のマージは null を無視するのでパイプラインごとは消せない。
+          nop: {}
+          otlphttp/mackerel:
+            endpoint: https://otlp-vaxila.mackerelio.com
+            headers:
+              Mackerel-Api-Key: ${env:MACKEREL_APIKEY}
+            sending_queue:
+              batch:
+                # Mackerel が受け付ける 1 リクエストの上限
+                max_size: 3500000
+                sizer: bytes
+        processors:
+          transform/service_name:
+            error_mode: ignore
+            log_statements:
+              # クラスタ全体のイベントであり、特定の namespace に属さない
+              - set(resource.attributes["service.namespace"], "lily")
+              - set(resource.attributes["service.name"], "kubernetes-events")
+        service:
+          pipelines:
+            logs:
+              exporters:
+                - otlphttp/mackerel
+              processors:
+                # 配列は置換されるため、chart 既定の memory_limiter と batch を明示する
+                - memory_limiter
+                - transform/service_name
+                - batch
+            metrics:
+              exporters:
+                - nop
+            traces:
+              exporters:
+                - nop
+      extraEnvs:
+        - name: MACKEREL_APIKEY
+          valueFrom:
+            secretKeyRef:
+              name: mackerel-api-key
+              key: apiKey
+      image:
+        repository: otel/opentelemetry-collector-k8s
+      mode: deployment
+      podSecurityContext:
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      presets:
+        kubernetesEvents:
+          enabled: true
+      replicaCount: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+
 resources:
   - ./resources/namespace.yaml
   - ./resources/secret.yaml

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -80,11 +80,16 @@ helmCharts:
               exporters:
                 - debug
               processors:
+                # Helm の values マージでは配列は置換されるため、chart が既定で
+                # 入れる memory_limiter と batch を明示的に書き戻す必要がある。
+                # 省略すると logs パイプラインからだけ両者が消える。
+                - memory_limiter
                 - filter/optout
                 - transform/severity
                 - transform/service_name
                 - transform/sampling
                 - probabilistic_sampler
+                - batch
       image:
         repository: otel/opentelemetry-collector-k8s
       mode: daemonset

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -142,8 +142,14 @@ helmCharts:
               exporters:
                 - otlphttp/mackerel
               processors:
+                # Pod ログと同じ severity 判定とサンプリングを通す。省略すると
+                # journald だけが常に全量送信され、サンプリング率を下げたときに
+                # 送信量の見積もりが崩れる。
                 - memory_limiter
+                - transform/severity
                 - transform/journald_service_name
+                - transform/sampling
+                - probabilistic_sampler
                 - batch
               receivers:
                 - otlp
@@ -285,4 +291,5 @@ helmCharts:
 
 resources:
   - ./resources/namespace.yaml
+  - ./resources/network-policy.yaml
   - ./resources/secret.yaml

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -42,8 +42,8 @@ helmCharts:
             error_mode: ignore
             log_statements:
               # WARN 以上は優先度 100 を付与し、サンプリング率に関わらず必ず通す
-              - set(attributes["sample_priority"], 100)
-                  where severity_number >= SEVERITY_NUMBER_WARN
+              - set(log.attributes["sample_priority"], 100)
+                  where log.severity_number >= SEVERITY_NUMBER_WARN
           transform/service_name:
             error_mode: ignore
             log_statements:
@@ -68,27 +68,27 @@ helmCharts:
             log_statements:
               # zerolog の ConsoleWriter 形式は ANSI カラーエスケープを含む。
               # 先に除去しないと後続の正規表現がレベル表記に一致しない。
-              - replace_pattern(body, "\\x1b\\[[0-9;]*m", "") where IsString(body)
+              - replace_pattern(log.body, "\\x1b\\[[0-9;]*m", "") where IsString(log.body)
               # filelog receiver の container operator は本文を文字列のまま body に
               # 入れるため、JSON ログも自動ではパースされない。明示的にパースして
               # map に変換することで、level の判定と Mackerel 画面での属性検索が効く。
-              - set(body, ParseJSON(body))
-                  where IsString(body) and IsMatch(body, "^\\s*\\{")
+              - set(log.body, ParseJSON(log.body))
+                  where IsString(log.body) and IsMatch(log.body, "^\\s*\\{")
               # JSON ログは level フィールドから判定する
-              - set(severity_number, SEVERITY_NUMBER_ERROR)
-                  where not IsString(body) and body["level"] == "error"
-              - set(severity_number, SEVERITY_NUMBER_WARN)
-                  where not IsString(body) and body["level"] == "warn"
-              - set(severity_number, SEVERITY_NUMBER_INFO)
-                  where not IsString(body) and body["level"] == "info"
+              - set(log.severity_number, SEVERITY_NUMBER_ERROR)
+                  where not IsString(log.body) and log.body["level"] == "error"
+              - set(log.severity_number, SEVERITY_NUMBER_WARN)
+                  where not IsString(log.body) and log.body["level"] == "warn"
+              - set(log.severity_number, SEVERITY_NUMBER_INFO)
+                  where not IsString(log.body) and log.body["level"] == "info"
               # テキストログは本文から推定する。zerolog の ERR / WRN 表記にも対応する
-              - set(severity_number, SEVERITY_NUMBER_ERROR)
-                  where IsString(body)
-                    and IsMatch(body, "(?i)\\b(err|error|fatal|panic)\\b")
-              - set(severity_number, SEVERITY_NUMBER_WARN)
-                  where IsString(body)
-                    and severity_number == SEVERITY_NUMBER_UNSPECIFIED
-                    and IsMatch(body, "(?i)\\b(wrn|warn|warning)\\b")
+              - set(log.severity_number, SEVERITY_NUMBER_ERROR)
+                  where IsString(log.body)
+                    and IsMatch(log.body, "(?i)\\b(err|error|fatal|panic)\\b")
+              - set(log.severity_number, SEVERITY_NUMBER_WARN)
+                  where IsString(log.body)
+                    and log.severity_number == SEVERITY_NUMBER_UNSPECIFIED
+                    and IsMatch(log.body, "(?i)\\b(wrn|warn|warning)\\b")
         service:
           pipelines:
             logs:

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -12,6 +12,11 @@ helmCharts:
     valuesInline:
       config:
         exporters:
+          # chart は metrics/traces のパイプラインを既定で作り、debug exporter に
+          # 出力する。このリポジトリではログしか扱わず、メトリクスは
+          # mackerel-container-agent が別途送っているため、収集結果を捨てる。
+          # Helm のマージは null を無視するのでパイプラインごとは消せない。
+          nop: {}
           otlphttp/mackerel:
             endpoint: https://otlp-vaxila.mackerelio.com
             headers:
@@ -100,6 +105,12 @@ helmCharts:
                 - transform/sampling
                 - probabilistic_sampler
                 - batch
+            metrics:
+              exporters:
+                - nop
+            traces:
+              exporters:
+                - nop
       extraEnvs:
         - name: MACKEREL_APIKEY
           valueFrom:

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -38,6 +38,12 @@ helmCharts:
             # まず全量送信して実データを確認する。
             sampling_percentage: 100
             sampling_priority: sample_priority
+          transform/journald_service_name:
+            error_mode: ignore
+            log_statements:
+              # ノードの systemd ログはクラスタ単位で扱う
+              - set(resource.attributes["service.namespace"], "lily")
+              - set(resource.attributes["service.name"], "systemd")
           transform/sampling:
             error_mode: ignore
             log_statements:
@@ -89,6 +95,13 @@ helmCharts:
                   where IsString(log.body)
                     and log.severity_number == SEVERITY_NUMBER_UNSPECIFIED
                     and IsMatch(log.body, "(?i)\\b(wrn|warn|warning)\\b")
+        receivers:
+          # Alloy から journald ログを OTLP で受け取る。journalctl を実行できない
+          # distroless イメージの代わりに、libsystemd を直接呼ぶ Alloy に読み取りを任せる。
+          otlp:
+            protocols:
+              grpc:
+                endpoint: 0.0.0.0:4317
         service:
           pipelines:
             logs:
@@ -105,6 +118,22 @@ helmCharts:
                 - transform/sampling
                 - probabilistic_sampler
                 - batch
+              # otlp receiver を追加した際、chart のプリセットが「シグナルに対応する
+              # receiver は明示指定がなければ自動的に追加する」ため、指定しないと
+              # journald 用の otlp receiver がこの Pod ログ用パイプラインにも二重に
+              # 接続されてしまう（journald のログが未整形のまま Mackerel に二重送信される）。
+              # そのため filelog のみを明示し、otlp の混入を防ぐ。
+              receivers:
+                - filelog
+            logs/journald:
+              exporters:
+                - otlphttp/mackerel
+              processors:
+                - memory_limiter
+                - transform/journald_service_name
+                - batch
+              receivers:
+                - otlp
             metrics:
               exporters:
                 - nop
@@ -145,6 +174,13 @@ helmCharts:
             - ALL
         privileged: false
         readOnlyRootFilesystem: true
+      service:
+        # chart は mode: daemonset のとき Service を既定で作らないため、Alloy から
+        # OTLP (:4317) を受けるために明示的に有効化する。daemonset モードで有効化
+        # すると internalTrafficPolicy が既定で Local になり、同一ノードの Pod
+        # にしか届かない。DaemonSet に対する Service としては望ましい挙動であり、
+        # lily は単一ノードクラスタのため実用上も問題ない。
+        enabled: true
 
   - name: opentelemetry-collector
     releaseName: otel-cluster

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -5,31 +5,49 @@ namespace: opentelemetry-collector
 helmCharts:
   # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
   - name: opentelemetry-collector
-    releaseName: opentelemetry-collector
+    releaseName: otel-agent
     namespace: opentelemetry-collector
     version: 0.159.0
     repo: https://open-telemetry.github.io/opentelemetry-helm-charts
     valuesInline:
+      config:
+        exporters:
+          debug:
+            verbosity: basic
+        service:
+          pipelines:
+            logs:
+              exporters:
+                - debug
       image:
         repository: otel/opentelemetry-collector-k8s
-      mode: deployment
+      mode: daemonset
+      podSecurityContext:
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+        # /var/log/pods 配下のログファイルが 0640 root:root であるため、
+        # 読み取りには root グループへの所属が必要になる
+        supplementalGroups:
+          - 0
       presets:
-        clusterMetrics:
-          enabled: true
-        hostMetrics:
-          enabled: true
-        kubeletMetrics:
-          enabled: true
         kubernetesAttributes:
           enabled: true
           extractAllPodAnnotations: true
           extractAllPodLabels: true
-        kubernetesEvents:
-          enabled: true
         logsCollection:
           enabled: true
           includeCollectorLogs: false
-      replicaCount: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
 
 resources:
   - ./resources/namespace.yaml
+  - ./resources/secret.yaml

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -13,12 +13,78 @@ helmCharts:
       config:
         exporters:
           debug:
-            verbosity: basic
+            # 変換結果を目視で確認するため detailed にする。
+            # Task 5 で Mackerel exporter に切り替える際に削除する。
+            verbosity: detailed
+        processors:
+          # 除外対象を先に落とし、後続の変換コストを減らす
+          filter/optout:
+            error_mode: ignore
+            logs:
+              log_record:
+                - 'resource.attributes["k8s.pod.annotation.mackerel.io/logs"] == "false"'
+          probabilistic_sampler:
+            # 初期値は 100%。発生源の是正により全量でも月 720 円に収まるため、
+            # まず全量送信して実データを確認する。
+            sampling_percentage: 100
+            sampling_priority: sample_priority
+          transform/sampling:
+            error_mode: ignore
+            log_statements:
+              # WARN 以上は優先度 100 を付与し、サンプリング率に関わらず必ず通す
+              - set(attributes["sample_priority"], 100)
+                  where severity_number >= SEVERITY_NUMBER_WARN
+          transform/service_name:
+            error_mode: ignore
+            log_statements:
+              - set(resource.attributes["service.namespace"],
+                    resource.attributes["k8s.namespace.name"])
+              - set(resource.attributes["service.name"],
+                    resource.attributes["k8s.deployment.name"])
+                  where resource.attributes["k8s.deployment.name"] != nil
+              - set(resource.attributes["service.name"],
+                    resource.attributes["k8s.daemonset.name"])
+                  where resource.attributes["service.name"] == nil
+                    and resource.attributes["k8s.daemonset.name"] != nil
+              - set(resource.attributes["service.name"],
+                    resource.attributes["k8s.statefulset.name"])
+                  where resource.attributes["service.name"] == nil
+                    and resource.attributes["k8s.statefulset.name"] != nil
+              - set(resource.attributes["service.name"],
+                    resource.attributes["k8s.pod.name"])
+                  where resource.attributes["service.name"] == nil
+          transform/severity:
+            error_mode: ignore
+            log_statements:
+              # zerolog の ConsoleWriter 形式は ANSI カラーエスケープを含む。
+              # 先に除去しないと後続の正規表現がレベル表記に一致しない。
+              - replace_pattern(body, "\\x1b\\[[0-9;]*m", "") where IsString(body)
+              # JSON ログは level フィールドから判定する
+              - set(severity_number, SEVERITY_NUMBER_ERROR)
+                  where not IsString(body) and body["level"] == "error"
+              - set(severity_number, SEVERITY_NUMBER_WARN)
+                  where not IsString(body) and body["level"] == "warn"
+              - set(severity_number, SEVERITY_NUMBER_INFO)
+                  where not IsString(body) and body["level"] == "info"
+              # テキストログは本文から推定する。zerolog の ERR / WRN 表記にも対応する
+              - set(severity_number, SEVERITY_NUMBER_ERROR)
+                  where IsString(body)
+                    and IsMatch(body, "(?i)\\b(err|error|fatal|panic)\\b")
+              - set(severity_number, SEVERITY_NUMBER_WARN)
+                  where IsString(body)
+                    and severity_number == SEVERITY_NUMBER_UNSPECIFIED
+                    and IsMatch(body, "(?i)\\b(wrn|warn|warning)\\b")
         service:
           pipelines:
             logs:
               exporters:
                 - debug
+              processors:
+                - filter/optout
+                - transform/severity
+                - transform/service_name
+                - transform/sampling
+                - probabilistic_sampler
       image:
         repository: otel/opentelemetry-collector-k8s
       mode: daemonset

--- a/k8s/system/opentelemetry-collector/resources/network-policy.yaml
+++ b/k8s/system/opentelemetry-collector/resources/network-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otel-agent-otlp
+
+spec:
+  # otel-agent は Mackerel API キーを持ち、受信したログをそのまま外部に転送する。
+  # OTLP receiver には認証がないため、到達できる Pod は偽ログを注入して
+  # 課金を増やしたりデータを汚染したりできる。到達元を Alloy だけに絞る。
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana-alloy
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alloy
+      ports:
+        - port: 4317
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: otel-agent
+  policyTypes:
+    - Ingress

--- a/k8s/system/opentelemetry-collector/resources/secret.yaml
+++ b/k8s/system/opentelemetry-collector/resources/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: mackerel-api-key
+
+spec:
+  itemPath: vaults/4mogpcwrvtvsnpooum4vcevwkm/items/lplwhjpvwu7x4vblj424d67rba

--- a/k8s/system/traefik/lily/values.yaml
+++ b/k8s/system/traefik/lily/values.yaml
@@ -88,11 +88,29 @@ logs:
           StartLocal: drop # time で十分
           StartUTC: drop
       headers:
-        defaultmode: keep
+        # 全ヘッダーを記録すると 1 レコード 3,554 bytes に達し、その 73.5% を
+        # ヘッダーが占めていた。drop を既定にすることで、新しい機密ヘッダーが
+        # 増えても明示的に keep しない限りログに載らない。
+        defaultmode: drop
         names:
-          Authorization: redact
-          Cookie: redact
-          X-Authentik-Jwt: redact
+          Accept-Language: keep
+          # Cloudflare のジオ情報。緯度経度 (Cf-Iplatitude/Cf-Iplongitude)、
+          # 郵便番号、タイムゾーンは所在地の特定精度が高すぎるため keep しない。
+          Cf-Connecting-Ip: keep
+          Cf-Ipcity: keep
+          Cf-Ipcountry: keep
+          Cf-Ray: keep
+          Cf-Visitor: keep
+          Origin: keep
+          Referer: keep
+          Sec-Ch-Ua: keep
+          Sec-Ch-Ua-Mobile: keep
+          Sec-Ch-Ua-Platform: keep
+          Sec-Fetch-Dest: keep
+          Sec-Fetch-Mode: keep
+          Sec-Fetch-Site: keep
+          User-Agent: keep
+          X-Real-Ip: keep
     format: json
   general:
     level: INFO


### PR DESCRIPTION
lily クラスタの Pod ログ、journald、Kubernetes Events を OpenTelemetry Collector 経由で Mackerel に送る基盤を追加します。
[Mackerel のログ機能](https://mackerel.io/ja/blog/entry/announcement/log-beta-release)は 2026 年 7 月にオープン β として公開され、正式リリース後は 70 円/GB の従量課金になります。
目的は、既存の Grafana Loki を将来的に縮小・廃止できるかの評価です。

設計は `docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md`、実装計画は `docs/superpowers/plans/2026-08-01_mackerel-log-ingestion.md` にあります。

## 構成

```
/var/log/pods ──> otel-agent (DaemonSet, 非 root)
                   ├ filelog receiver
                   ├ k8sattributes / memory_limiter
                   ├ transform (ANSI 除去, JSON パース, severity 判定)
                   ├ filter    (オプトアウト判定)
                   ├ transform (サービス名, サンプル優先度)
                   ├ probabilistic_sampler
                   └ batch                            ──> Mackerel (OTLP/HTTP)
                      ↑ OTLP :4317
journald ──> Alloy ───┘  (読み取りのみ。送信は Collector が行う)

k8s events ──> otel-cluster (Deployment ×1, 非 root)  ──> Mackerel
```

Mackerel への送信は Collector に一元化し、API キーを持つのも Collector だけにしています。
journald だけを Alloy 経由にしたのは、OpenTelemetry の journald receiver が `journalctl` を実行する実装である一方、公式イメージが distroless で `sh` すら含まないためです。
Alloy の `loki.source.journal` は libsystemd を直接呼ぶ自前実装で、既に稼働しています。

既存の Alloy → Loki の経路は変更していません。評価期間中は並走させます。

## 発生源の是正

実測の結果、送信量の 88% がデバッグログと正常時のアクセスログでした。
サンプリング率を調整するより、発生源を正すほうが効果が大きいと判断しました。

| 対象 | 変更 | 効果 |
| --- | --- | --- |
| nebula backend / worker | ConfigMap に `LOG_LEVEL=info` | -1.72 GB/日 |
| traefik | アクセスログのヘッダーを 16 個に限定 | 1 レコード 3,554 → 約 1,422 bytes |

nebula はアプリケーションの既定値である DEBUG のまま稼働しており、SQL クエリの全文を出力していました。
traefik は全ヘッダーを記録しており、その 73.5% がヘッダーでした。

| 段階 | クラスタ全体 | 正式リリース後の月額 |
| --- | --- | --- |
| 現状 | 2.97 GB/日 | 3,136 円 |
| nebula 是正後 | 1.25 GB/日 | 1,320 円 |
| + traefik 是正後 | **0.68 GB/日** | **約 720 円** |

サンプリングは機構を入れたうえで初期値 100%（実質無効）にしています。
発生源の是正により全量送信でも月 720 円に収まるため、実データを見てから絞る方針です。

## セキュリティ

Collector は非 root（uid 10001）で動かします。
ノード上の `/var/log/pods/**/*.log` が `0640 root:root` であるため、`supplementalGroups: [0]` で root グループへの所属だけを付与しています。

```yaml
podSecurityContext:
  runAsNonRoot: true
  runAsUser: 10001
  supplementalGroups: [0]
  seccompProfile:
    type: RuntimeDefault
securityContext:
  privileged: false
  allowPrivilegeEscalation: false
  capabilities:
    drop: [ALL]
  readOnlyRootFilesystem: true
```

`mode: daemonset` は既定で 6 つの hostPort をノード IP に公開します。
この Collector は Mackerel API キーを持つため、認証なしの受信口を LAN に開けません。
`ports` で jaeger / zipkin / otlp-http を無効化し、`otlp` は `hostPort: 0` にしています。
Alloy からの接続は Service（`internalTrafficPolicy: Local`）経由で足ります。

OTLP receiver には認証がないため、`grafana-alloy` namespace の Alloy Pod から TCP/4317 のみを許可する NetworkPolicy を追加しています。
`hostPort: 0` はノード IP への露出を防ぐだけで、Service 経由のクラスタ内アクセスは別途塞ぐ必要があります。

traefik のヘッダー削減では `defaultmode` を `drop` に反転しました。
これにより `Authorization` / `Cookie` の `redact` 指定が不要になり、新しい機密ヘッダーが増えても明示的に `keep` しない限り記録されません。
Cloudflare の緯度経度・郵便番号・タイムゾーンは、所在地の特定精度が高いため除外しています。

## オプトアウト

Pod のアノテーションでワークロード単位に除外できます。

```yaml
metadata:
  annotations:
    mackerel.io/logs: "false"
```

## 検証

ブランチ上で実施したもの。

- `mise exec -- go run ./cmd/build-manifests`：153 ディレクトリすべて成功
- `mise exec -- pnpm eslint`：エラーなし
- `otelcol validate`（実際にデプロイされるイメージタグ 0.154.0）：otel-agent / otel-cluster とも成功
- `kustomize build` 出力での目視確認：securityContext、hostPort の不在、パイプラインの構成

**実機での動作確認はマージ後に実施します。** ArgoCD が `targetRevision: HEAD`（master）を追跡するため、feature ブランチでは同期されないためです。

### マージ後に確認すること

- [ ] Collector の Pod が非 root（uid 10001）で起動し、`/var/log/pods` を読めているか
- [ ] Mackerel の画面で `service.namespace` ごとにログが分類されて表示されるか
- [ ] ANSI エスケープが除去され、severity が正しく判定されているか
- [ ] `mackerel.io/logs: "false"` を付けたワークロードのログが届かないか
- [ ] journald と Kubernetes Events が届いているか
- [ ] 是正後の Loki 受信量が想定どおり減っているか（nebula 69 MB/h → 10 MB/h 前後、traefik 3,699 → 1,400 bytes/rec 前後）

## 補足: kube-linter の検査範囲

作業中に判明した既知の穴です。このブランチでは対処していません。

`kube-linter` は `helmCharts` で生成されるリソースを検査していません。
`opentelemetry-collector` も `traefik` も指摘 0 件で、633 件の既存指摘はすべて `resources:` で直接書かれた YAML に対するものです。
本 PR では `kustomize build` 出力の目視確認と `otelcol validate` で担保しています。

## 動物界における比擬

この構成は、**アリの巣における触角接触による情報伝達**に似ています。

働きアリは巣内で出会うたびに触角を触れ合わせ、相手の体表炭化水素から「どの仕事に従事しているか」を読み取ります。
ただし、すべての接触を女王に報告するわけではありません。
巣の入口付近で外敵の匂いを検知した個体だけが、警報フェロモンを放出して情報を上位に伝えます。
日常的な接触は現場で処理され、上には流れません。

本 PR の severity ベースのサンプリングは、これと同じ構造をとります。
WARN 以上のログは無条件に Mackerel へ送られ（警報フェロモン）、それ未満は必要に応じて間引かれます（現場で完結する日常の接触）。
すべてを中央に送らないことが、巣全体の情報処理の効率を保っています。

**journald の収集を Alloy に任せた点**は、ハキリアリの多型カーストに対応します。
ハキリアリのコロニーには、葉を切り出す大型個体と、それを運ぶ中型個体、菌園を世話する小型個体がいます。
体の大きさが仕事に最適化されており、大型個体は葉を運べません。
OpenTelemetry Collector は distroless という「軽量化された体」を持つがゆえに `journalctl` という道具を扱えず、libsystemd を直接扱える Alloy に読み取りを委ねています。
運搬（Mackerel への送信）は引き続き Collector が担い、役割が分かれています。

**発生源の是正**は、ミツバチの巣門での花粉搬入量の調整に相当します。
巣に花粉が過剰に蓄積すると、採餌蜂は搬入を減らし、蜜の採集に切り替えます。
巣の中で「もう十分だ」という信号が上流の行動を変えるのです。
nebula の DEBUG ログを止め、traefik のヘッダーを削ったのは、下流（Mackerel の課金）の都合を上流（アプリケーションの出力）に還元した結果です。
下流で濾すより、上流で出さないほうが系全体の負荷が下がります。

**オプトアウトのアノテーション**は、社会性昆虫の巣仲間認識に近い仕組みです。
アリは体表炭化水素の組成で巣仲間かどうかを判定し、異物と認識した個体を排除します。
`mackerel.io/logs: "false"` は Pod が自ら掲げる標識であり、Collector はそれを読んで送信対象から外します。
判定の基準が対象自身に書かれている点が共通しています。

なお実装中、この標識の読み取りに使う属性名を誤っており、**標識を掲げても認識されない状態**でした。
最終レビューで発見して修正しています。
アリの巣仲間認識も、炭化水素の組成がわずかに違うだけで同巣個体が攻撃対象になることが知られており、認識キーの厳密さという点でも似た脆さを持っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iphM8idUrQkVVAqkxc1wL
