### PR TITLE
fix: Mackerel ログ送信でサンプラーが全ログを破棄していた問題を修正

### DIFF
--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -37,13 +37,18 @@ helmCharts:
                 # 接頭辞は付かない。誤ると nil 比較になり静かに機能しなくなる。
                 - 'resource.attributes["mackerel.io/logs"] == "false"'
           probabilistic_sampler:
+            attribute_source: record
+            from_attribute: sample_key
+            # Pod ログには trace ID がないため、既定の attribute_source: traceID の
+            # ままだと fail_closed: true により全ログが破棄される。100% を指定しても
+            # 「trace ID を持つログの 100%」の意味にしかならず、実測で 98.8% が
+            # 消えていた。種を k8s.pod.uid に明示する。
+            #
+            # 率を下げると Pod 単位で採否が決まる。採用された Pod のログは全量残り、
+            # 残りは全破棄される（WARN 以上は sampling_priority で常に通る）。
+            mode: hash_seed
             # 初期値は 100%。発生源の是正により全量でも月 720 円に収まるため、
             # まず全量送信して実データを確認する。
-            #
-            # 100 未満に下げるときは attribute_source と from_attribute の指定が
-            # 必須になる。Pod ログには trace ID がなく、既定の traceID を種にすると
-            # WARN 未満が指定率ではなく 0% になる。種の選び方は設計文書の
-            # 「サンプリング」節を参照する。
             sampling_percentage: 100
             sampling_priority: sample_priority
           transform/journald_service_name:
@@ -58,6 +63,11 @@ helmCharts:
               # WARN 以上は優先度 100 を付与し、サンプリング率に関わらず必ず通す
               - set(log.attributes["sample_priority"], 100)
                   where log.severity_number >= SEVERITY_NUMBER_WARN
+              # probabilistic_sampler の attribute_source: record はログレコード
+              # 属性しか見ない。k8s.pod.uid は k8sattributes がリソース属性に
+              # 付けるため、ここでレコード属性へ複写しないと参照できない。
+              - set(log.attributes["sample_key"], resource.attributes["k8s.pod.uid"])
+                  where resource.attributes["k8s.pod.uid"] != nil
           transform/service_name:
             error_mode: ignore
             log_statements:

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -51,6 +51,27 @@ helmCharts:
             # まず全量送信して実データを確認する。
             sampling_percentage: 100
             sampling_priority: sample_priority
+          transform/journald_sampling:
+            error_mode: ignore
+            log_statements:
+              # WARN 以上は優先度 100 を付与し、サンプリング率に関わらず必ず通す
+              - set(log.attributes["sample_priority"], 100)
+                  where log.severity_number >= SEVERITY_NUMBER_WARN
+              # journald は Alloy から OTLP で届くため k8sattributes を通らず、
+              # k8s.pod.uid を持たない。Pod ログ用の種を流用すると空のままになり、
+              # fail_closed: true で WARN 未満が全破棄される。
+              # systemd の unit を種にすることで、率を下げたときに unit 単位で
+              # 採否が決まり、選ばれた unit のログは前後関係を保ったまま残る。
+              #
+              # unit が OTLP 変換後にリソース属性として現れるかは
+              # otelcol.receiver.loki の変換仕様に依存し、journald が 1 行も
+              # 流れていない現状では実測できていない。取れなかった場合は固定値に
+              # 落ちるため、率を下げると journald 全体が全通過か全破棄の二択になる。
+              # 率を下げる前に、実際に unit が取れているかを確認すること。
+              - set(log.attributes["sample_key"], resource.attributes["unit"])
+                  where resource.attributes["unit"] != nil
+              - set(log.attributes["sample_key"], "systemd")
+                  where log.attributes["sample_key"] == nil
           transform/journald_service_name:
             error_mode: ignore
             log_statements:
@@ -66,8 +87,15 @@ helmCharts:
               # probabilistic_sampler の attribute_source: record はログレコード
               # 属性しか見ない。k8s.pod.uid は k8sattributes がリソース属性に
               # 付けるため、ここでレコード属性へ複写しないと参照できない。
+              #
+              # 種が空のままだと fail_closed: true により全破棄される。この
+              # パイプラインは filelog 由来の Pod ログ専用で k8sattributes を
+              # 通るため k8s.pod.uid は必ず存在するが、万一欠けた場合に
+              # 静かに消えることを避けて service.name を代替の種にする。
               - set(log.attributes["sample_key"], resource.attributes["k8s.pod.uid"])
                   where resource.attributes["k8s.pod.uid"] != nil
+              - set(log.attributes["sample_key"], resource.attributes["service.name"])
+                  where log.attributes["sample_key"] == nil
           transform/service_name:
             error_mode: ignore
             log_statements:
@@ -155,10 +183,12 @@ helmCharts:
                 # Pod ログと同じ severity 判定とサンプリングを通す。省略すると
                 # journald だけが常に全量送信され、サンプリング率を下げたときに
                 # 送信量の見積もりが崩れる。
+                # ただしサンプリングの種は Pod ログ用と共用できない
+                # （journald は k8s.pod.uid を持たない）ため、専用のものを使う。
                 - memory_limiter
                 - transform/severity
                 - transform/journald_service_name
-                - transform/sampling
+                - transform/journald_sampling
                 - probabilistic_sampler
                 - batch
               receivers:


### PR DESCRIPTION
#9724 のマージ後、実機で動作確認したところ、`probabilistic_sampler` が受信ログの 98.8% を破棄していることが判明しました。

## 症状

```
otelcol_processor_incoming_items{processor="probabilistic_sampler"} 4757
otelcol_processor_outgoing_items{processor="probabilistic_sampler"}   59
```

`sampling_percentage: 100` を指定していたにもかかわらず、通っていたのは 59 件だけでした。

## 原因

Pod ログには trace ID がありません。`probabilistic_sampler` の既定は `attribute_source: traceID` で、trace ID を持たないレコードは `fail_closed: true`（既定）により破棄されます。`sampling_percentage: 100` は「**trace ID を持つログの** 100%」の意味にしかなりません。

通っていた 59 件は `transform/sampling` が付与した `sample_priority: 100`（WARN 以上）を持つログです。優先度による強制通過の経路だけが機能しており、**WARN 未満のログは一切 Mackerel に届いていませんでした**。

この罠は設計文書に記載していましたが、「サンプリング率を下げるときに必要」と誤認していました。実際には **100% でも必要**でした。

## 修正

ハッシュの種を `k8s.pod.uid` に明示します。

```yaml
probabilistic_sampler:
  mode: hash_seed
  attribute_source: record
  from_attribute: sample_key
  sampling_percentage: 100
  sampling_priority: sample_priority
```

`attribute_source: record` はログレコード属性しか参照せず、`k8s.pod.uid` は `k8sattributes` が**リソース属性**に付けます。そのままでは参照できないため、`transform/sampling` でレコード属性へ複写します。

```yaml
- set(log.attributes["sample_key"], resource.attributes["k8s.pod.uid"])
    where resource.attributes["k8s.pod.uid"] != nil
```

将来 `sampling_percentage` を下げた場合は Pod 単位で採否が決まります。採用された Pod のログは全量残り、残りは全破棄されます（WARN 以上は `sampling_priority` により常に通過）。

## 検証

- `mise exec -- go run ./cmd/build-manifests`：成功
- `mise exec -- pnpm eslint`：エラーなし
- `otelcol validate`（0.154.0）：成功

マージ後、`otelcol_processor_outgoing_items{processor="probabilistic_sampler"}` が incoming と一致することを確認します。

## 動物界における比擬

これは**アリの道しるべフェロモンの濃度閾値**に起きた誤りに似ています。

採餌アリは餌場からの帰路にフェロモンを分泌し、後続の個体はその濃度が閾値を超えたときだけ追従します。閾値が高すぎると、実際には餌があるのに誰も follow せず、行列が形成されません。餌の有無ではなく、**判定基準の設定**が行動を止めます。

今回、ログは正しく読まれ、severity も付与され、パイプラインの手前まで届いていました。止まっていたのは最後の 1 段だけです。しかも「何も届かない」ではなく「警報だけ届く」という部分的な機能によって、壊れていることが見えにくくなっていました。巣の警報系だけが生きていて、日常の採餌情報が一切共有されていない状態です。

発見できたのは、`otelcol_processor_incoming_items` と `outgoing_items` を processor ごとに突き合わせたためでした。出口だけを見れば「59 件送信成功」であり、正常に見えます。**通過数ではなく、各段での減衰を見る**必要がありました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iphM8idUrQkVVAqkxc1wL