### PR TITLE
fix(grafana-alloy): journald を読めるよう machine-id をマウントする

### DIFF
--- a/k8s/apps/grafana-alloy/kustomization.yaml
+++ b/k8s/apps/grafana-alloy/kustomization.yaml
@@ -16,7 +16,22 @@ helmCharts:
           create: false
           key: config.alloy
         mounts:
+          # loki.source.journal は /etc/machine-id を読んで自分のマシンの
+          # ジャーナルディレクトリ (/var/log/journal/<machine-id>/) を特定する。
+          # コンテナ内の /etc/machine-id は空のため、ホストのものをマウントしないと
+          # 対象が見つからず、エラーも出ないまま 1 行も読めない。
+          extra:
+            - name: etc-machine-id
+              mountPath: /etc/machine-id
+              readOnly: true
           varlog: true
+      controller:
+        volumes:
+          extra:
+            - name: etc-machine-id
+              hostPath:
+                path: /etc/machine-id
+                type: File
 
 resources:
   - ./resources/dns.yaml


### PR DESCRIPTION
`loki.source.journal` が journald から **1 行も読めていませんでした**。#9724 で journald を Mackerel に橋渡しする経路を作りましたが、そもそも読み取り元が空だったため何も流れていませんでした。

## 症状

```
loki_source_journal_target_lines_total{component_id="loki.source.journal.node_systemd_journal"} 0
```

累計 0 行です。Loki 側でも journald のログは 0 行で、**以前からこの状態**でした。

にもかかわらずコンポーネントは正常を報告し続けます。

```
loki.source.journal.node_systemd_journal
  health: healthy | journal tailer is running
```

エラーログも一切出ません。

## 原因

`/etc/machine-id` が空でした。

| 項目 | 値 |
|---|---|
| コンテナの `/etc/machine-id` | **0 バイト** |
| ホストのジャーナルディレクトリ | `/var/log/journal/792b115fcb474eee96c74ddcc090d8b9/` |
| マウント | `/var/log` のみ。`/etc/machine-id` は未マウント |

`loki.source.journal` は machine-id を読んで自分のマシンのジャーナルディレクトリを特定します。machine-id が空だと対象が見つかりませんが、systemd の API はこれをエラーとせず空の結果を返します。そのため tailer は正常に起動したまま、読むものがない状態で待ち続けます。

`/var/log` 自体は正しくマウントされており、ファイルの読み取りも可能でした（コンテナ内から `head` で確認済み）。活発に書き込まれてもいます（`system.journal` が 58MB、直近まで更新あり）。**配線はすべて正しく、machine-id だけが欠けていました。**

## 修正

ホストの `/etc/machine-id` を読み取り専用でマウントします。

```yaml
alloy:
  mounts:
    extra:
      - name: etc-machine-id
        mountPath: /etc/machine-id
        readOnly: true
    varlog: true
controller:
  volumes:
    extra:
      - name: etc-machine-id
        hostPath:
          path: /etc/machine-id
          type: File
```

`hostPath.type: File` により、ホストに `/etc/machine-id` が存在しない場合は Pod の起動が失敗します。空マウントで無言のまま読めない状態に戻るより、起動時に気付けるほうが望ましいと判断しました。

## 検証

- `mise exec -- go run ./cmd/build-manifests`：成功
- `mise exec -- pnpm eslint`：エラーなし
- `kustomize build` 出力で `volumeMounts` と `volumes` の両方が生成されることを確認

マージ後、`loki_source_journal_target_lines_total` が 0 から増加することを確認します。あわせて Mackerel 側に `lily / systemd` のログが届くこと、および `otelcol.receiver.loki` の変換後に `unit` 属性が取れるか（#9726 のコメントで未確認としていた点）も確認できます。

## 動物界における比擬

これは**ミツバチの巣箱の入口識別**に起きた誤りに似ています。

働き蜂は帰巣時、自分の巣を体表の匂いと巣門の位置で識別します。養蜂家が巣箱を数十センチ移動させると、蜂は元の位置に戻ってきて空中で滞留し、目の前に巣があっても入れません。飛翔能力にも嗅覚にも問題はなく、**照合すべき基準点だけが失われて**います。

今回、Alloy は読む力（ファイルアクセス権）も、運ぶ力（OTLP 転送）も持っていました。欠けていたのは「どのディレクトリが自分のものか」を照合する machine-id だけです。しかも蜂が空中で元気に飛び回っているのと同様、コンポーネントは `healthy` を報告し続けました。**動いていることと、仕事をしていることは別**でした。

発見できたのは `loki_source_journal_target_lines_total` という累計カウンタを見たためです。health だけを見れば正常、ログを見てもエラーなし。**「何行読んだか」を問うて初めて 0 が見えました。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iphM8idUrQkVVAqkxc1wL