### PR TITLE
chore: Grafana Loki を廃止する

### DIFF
--- a/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
@@ -440,6 +440,46 @@ redact の指定漏れという事故が構造的に起きなくなる。
 - **`logsCollection` preset の `includeCollectorLogs: false` は自身のリリース分しか除外しない**。`otel-cluster` を追加した際に、そのログが Mackerel に送られる状態になった。`filelog.exclude` を `otel-*` パターンで上書きして両方を除外している。この上書きはリリース名の命名規則に暗黙的に依存する。
 - **ログ監視が未実装であるため、Loki 廃止の判断は保留する**。Loki 側でログを起点にしたアラートを運用している場合、Mackerel だけでは代替できない。
 
+## Loki の廃止（2026-08-01 追記）
+
+評価の結果、Loki を廃止した。
+Mackerel への送信が全経路（Pod ログ、journald、Kubernetes Events）で成立したため、並走の必要がなくなった。
+
+廃止によって回収したもの。
+
+| 項目 | 内容 |
+| --- | --- |
+| Pod | loki-0、loki-chunks-cache-0、loki-results-cache-0 の 3 つ |
+| ディスク | 10Gi のローカル PV |
+
+Alloy は DaemonSet 1 Pod として残る。
+役割は journald の読み取りだけに縮小し、Pod ログの収集と Loki への書き込みは削除した。
+Collector の公式イメージが distroless で `journalctl` を含まず、journald receiver を使えないためである。
+
+PV の `persistentVolumeReclaimPolicy` は `Retain` であるため、ホスト上の `/mnt/local/grafana-loki/data` は残る。
+不要であれば手動で削除する。
+
+`k8s/apps/grafana-loki/` のマニフェストは削除せず残す。
+本リポジトリでは廃止したアプリのマニフェストを残し、ApplicationSet のエントリをコメントアウトして配信だけを止める慣習に従う（`feedchime`、`releasechime-*` などが同じ形である）。
+再開するときはコメントを外すだけでよい。
+
+### 廃止時点の送信量
+
+| 経路 | GB/日 | 占有率 |
+| --- | --- | --- |
+| Pod ログ | 1.128 | 99.6% |
+| journald | 0.005 | 0.4% |
+| 合計 | 1.133 | |
+
+月間 34.4 GB、正式リリース後の月額は約 2,409 円になる。
+当初の試算 0.68 GB/日 を上回った主因は Traefik のリクエスト量であり、1 レコードあたりのサイズ削減（3,554 → 1,438 bytes）は想定どおり効いている。
+
+送信量を下げる余地は次の順に大きい。
+
+- Traefik の 2xx を除外する（-0.4 GB/日 前後）
+- サンプリング率を下げる（50% で -0.5 GB/日）。`unit` 属性が取得できることは確認済みであり、journald は unit 単位で採否が決まる
+- `kube-system` をオプトアウトする（-0.15 GB/日）
+
 ## 採用しなかった選択肢
 
 journald の収集について、Alloy 以外の手段も検討した。

--- a/k8s/apps/grafana-alloy/config/config.alloy
+++ b/k8s/apps/grafana-alloy/config/config.alloy
@@ -1,51 +1,7 @@
-loki.write "default" {
-	endpoint {
-		url = "http://loki.grafana-loki:3100/loki/api/v1/push"
-	}
-}
-
-discovery.kubernetes "pod" {
-	role = "pod"
-}
-
-discovery.relabel "pod_logs" {
-	targets = discovery.kubernetes.pod.targets
-
-	rule {
-		source_labels = ["__meta_kubernetes_namespace"]
-		action        = "replace"
-		target_label  = "namespace"
-	}
-
-	rule {
-		source_labels = ["__meta_kubernetes_pod_name"]
-		action        = "replace"
-		target_label  = "pod_name"
-	}
-
-	rule {
-		source_labels = ["__meta_kubernetes_pod_container_name"]
-		action        = "replace"
-		target_label  = "container_name"
-	}
-
-	rule {
-		source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-		action        = "replace"
-		target_label  = "app_name"
-	}
-}
-
-loki.source.kubernetes "pod_logs" {
-	targets    = discovery.relabel.pod_logs.output
-	forward_to = [loki.write.default.receiver]
-}
-
-// loki.source.kubernetes_events "events" {
-// 	job_name   = "integrations/kubernetes/eventhandler"
-// 	log_format = "logfmt"
-// 	forward_to = [loki.write.default.receiver]
-// }
+// Loki を廃止したため、Alloy の役割は journald の読み取りだけに縮小した。
+// Pod ログは OpenTelemetry Collector が filelog receiver で直接読む。
+// Alloy が残っているのは、Collector の公式イメージが distroless で
+// journalctl を含まず journald receiver を使えないためである。
 
 loki.relabel "node_systemd_journal" {
 	forward_to = []
@@ -58,17 +14,13 @@ loki.relabel "node_systemd_journal" {
 }
 
 loki.source.journal "node_systemd_journal" {
-	forward_to    = [
-		loki.write.default.receiver,
-		otelcol.receiver.loki.journald.receiver,
-	]
+	forward_to    = [otelcol.receiver.loki.journald.receiver]
 	relabel_rules = loki.relabel.node_systemd_journal.rules
 	labels        = {component = "loki.source.journal"}
 }
 
 // journald のログを OpenTelemetry Collector に転送する。
-// Collector の公式イメージは distroless で journalctl を含まないため、
-// journald の読み取りだけを Alloy が担い、Mackerel への送信は Collector が行う。
+// 読み取りだけを Alloy が担い、Mackerel への送信は Collector が行う。
 otelcol.receiver.loki "journald" {
 	output {
 		logs = [otelcol.exporter.otlp.collector.input]

--- a/k8s/system/argo-cd/resources/application-set-lily.yaml
+++ b/k8s/system/argo-cd/resources/application-set-lily.yaml
@@ -144,10 +144,10 @@ spec:
             namespace: orb
             path: k8s/apps/orb
             project: apps
-          - name: grafana-loki
-            namespace: grafana-loki
-            path: k8s/apps/grafana-loki
-            project: apps
+          # - name: grafana-loki
+          #   namespace: grafana-loki
+          #   path: k8s/apps/grafana-loki
+          #   project: apps
           - name: grafana-alloy
             namespace: grafana-alloy
             path: k8s/apps/grafana-alloy


### PR DESCRIPTION
Mackerel へのログ送信が全経路（Pod ログ、journald、Kubernetes Events）で成立したため、評価のための並走を終了し Loki を廃止します。

**Draft にしています。** 廃止は不可逆な操作を含むため、下記の確認事項に目を通してから ready にしてください。

## 変更内容

| ファイル | 変更 |
|---|---|
| `k8s/apps/grafana-loki/` | **変更なし（マニフェストは残す）** |
| `k8s/system/argo-cd/resources/application-set-lily.yaml` | `grafana-loki` エントリを**コメントアウト** |
| `k8s/apps/grafana-alloy/config/config.alloy` | Pod ログ収集と Loki 書き込みを削除 |
| `docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md` | 廃止の記録を追記 |

## マニフェストは残します

本リポジトリでは、廃止したアプリのマニフェストを削除せず残し、ApplicationSet のエントリをコメントアウトして配信だけを止める慣習に従っています（`feedchime`、`releasechime-*` が同じ形です）。

ArgoCD 側の効果はエントリを削除した場合と同じで、Application が消え `prune: true` により子リソースが回収されます。違いは再開のしやすさで、コメントを外すだけで復帰できます。`kustomization.yaml` が残るため Renovate も chart のバージョンを追い続けます。

## Alloy に残すもの・消すもの

Alloy は **DaemonSet 1 Pod として残ります**。Collector の公式イメージが distroless で `journalctl` を含まず、journald receiver を使えないためです。

| コンポーネント | 扱い | 理由 |
|---|---|---|
| `loki.write "default"` | 削除 | 送信先が消える |
| `discovery.kubernetes` / `discovery.relabel` | 削除 | Pod ログ収集専用。Collector が直接読む |
| `loki.source.kubernetes "pod_logs"` | 削除 | 同上 |
| `loki.relabel "node_systemd_journal"` | **残す** | journald の `unit` ラベル付与 |
| `loki.source.journal` | **残す** | journald の読み取り役 |
| `otelcol.receiver.loki` / `otelcol.exporter.otlp` | **残す** | Collector への橋渡し |

`loki.relabel` は名前に反して Loki 本体とは無関係です。これを消すと `unit` が失われ、**journald のサンプリングの種が固定値に落ちます**（率を下げたとき全通過か全破棄の二択になる）。残す必要があります。

## 回収されるリソース

| 項目 | 内容 |
|---|---|
| Pod | `loki-0`、`loki-chunks-cache-0`、`loki-results-cache-0` の **3 つ** |
| ディスク | **10Gi** のローカル PV |

## ⚠️ 確認事項

### 1. ホスト上のデータは残ります

PV の `persistentVolumeReclaimPolicy` は `Retain` です。ArgoCD の `prune: true` が PV/PVC を削除しても、**ホスト上の `/mnt/local/grafana-loki/data` は残ります**。不要であれば手動で削除してください。

```console
$ sudo du -sh /mnt/local/grafana-loki/data
$ sudo rm -rf /mnt/local/grafana-loki/data
```

### 2. 過去 30 日分のログが失われます

Loki には保持期間 30 日でログが蓄積されています。Mackerel 側にあるのは **2026-08-01 14:27 以降**のものだけです。それ以前のログを参照する予定があるなら、マージ前に取り出してください。

### 3. Grafana のデータソース

リポジトリ内の Grafana マニフェストに Loki への参照はありませんでした（`k8s/apps/grafana/` に該当なし、実クラスタの ConfigMap にも 0 件）。UI から手動で追加されている場合は、マージ後にデータソースがエラーになります。手動で削除してください。

## 廃止時点の送信量

| 経路 | GB/日 | 占有率 |
|---|---|---|
| Pod ログ | 1.128 | 99.6% |
| journald | 0.005 | 0.4% |
| **合計** | **1.133** | |

月間 34.4 GB、正式リリース後（2026年秋頃）の月額は **約 2,409 円**です。β期間中は無料です。

当初試算の 0.68 GB/日 を上回った主因は Traefik のリクエスト量です。1 レコードのサイズ削減（3,554 → 1,438 bytes）は想定どおり効いており、単価ではなく件数の差です。

送信量を下げる余地（効果順）:

- Traefik の 2xx を除外（-0.4 GB/日 前後）
- サンプリング率を 50% に（-0.5 GB/日）。`unit` 属性の取得は確認済み
- `kube-system` をオプトアウト（-0.15 GB/日）

## 検証

- `mise exec -- go run ./cmd/build-manifests`：成功
- `mise exec -- pnpm eslint`：エラーなし
- `config.alloy` から Loki 書き込みと Pod ログ収集が消え、journald 経路が残ることを確認

マージ後、Alloy が journald を読み続けること（`loki_source_journal_target_lines_total` の増加）と、Mackerel への送信が継続することを確認します。

## ロールバック

`selfHeal: true` のため、戻すには master への再コミットが必要です。ApplicationSet のコメントを外せば Loki は再作成されますが、**PV は再バインドされるものの中身は削除前の状態**です（`Retain` のため）。手動でホストのデータを消した後は復元できません。

## 動物界における比擬

これは**渡り鳥の中継地の放棄**にあたります。

シギやチドリの仲間は、越冬地と繁殖地のあいだに複数の中継地を持ちます。ある中継地の餌場が失われると、その地点を飛ばして次まで一気に飛ぶ個体群が現れます。ただし飛べるようになったのは、途中で休まなくても届く体力が確認できたからです。先に中継地を潰してから飛べるかを試すのではありません。

本 PR も同じ順序を踏んでいます。Mackerel への送信が全経路で成立し、送信量と費用を実測し、`unit` 属性の取得まで確認したうえで Loki を外します。並走期間は、届くことを確かめるための時間でした。

**マニフェストを残すことは、巣そのものを壊さずに空けておくことに似ています。** ツバメは繁殖期が終われば巣を離れますが、巣は壊されずに残り、翌年に同じ個体が戻って補修して使うことがあります。作り直すより costly でないからです。ApplicationSet のエントリをコメントアウトするだけの措置も、同じ経済に基づいています。

**Alloy が残ることは、中継地そのものではなく「そこにある目印」が残ることに似ています。** 渡り鳥は地形や磁場を航法の手がかりにしており、餌場が消えても目印としての価値は残ります。Alloy は保管役ではなくなりましたが、Collector が読めない journald を読む目として機能し続けます。名前に `loki` を含むコンポーネントが残るのも、その役割が Loki と無関係だからです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iphM8idUrQkVVAqkxc1wL