### PR TITLE
fix(opentelemetry-collector): ログレベルの判定を修正する

### DIFF
--- a/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
+++ b/docs/superpowers/specs/2026-08-01_mackerel-log-ingestion.md
@@ -271,16 +271,25 @@ nebula のログは zerolog の ConsoleWriter 形式であり、レベル表記�
 1. ANSI エスケープの除去
    replace_pattern(body, "\x1b\[[0-9;]*m", "") where IsString(body)
 
-2. JSON ログなら level フィールドから判定
-   set(severity_number, SEVERITY_NUMBER_ERROR) where body["level"] == "error"
+2. レベル表記を log.cache["level"] に集約する
+   journald の PRIORITY → 構造化ログのキー → テキストログの表記、の順に見る
 
-3. テキストログは本文から推定（zerolog の ERR / WRN 表記にも対応する）
-   set(severity_number, SEVERITY_NUMBER_ERROR)
-     where IsString(body) and IsMatch(body, "(?i)\b(err|error|fatal|panic)\b")
+3. 集約した表記を小文字に正規化し、severity_number と severity_text へ変換する
 ```
 
+当初は「本文全体に `(?i)\b(err|error|fatal|panic)\b` が一致するか」で判定していたが、これは二重に誤っていた。
+
+- **判定漏れ**：ERROR と WARN のルールしか無く、INFO と DEBUG に相当する規則が存在しなかった。実クラスタのログ 1299 行のうち 1094 行 (84.2%) が `UNSPECIFIED` のまま送られていた
+- **誤判定**：メッセージ中の単語に引きずられ、`INFO ... Warning: watch ended with error` のような行が ERROR になっていた
+
+本文全体への部分一致はやめ、**先頭 72 文字以内で、区切り文字に挟まれたレベル表記のうち最も左に現れたもの**を切り出す方式に改めた。
+レベル表記の「位置」と「綴り」を規定することで、メッセージ本文に含まれる同じ単語を拾わなくなる。
+
 判定できなかったログは `UNSPECIFIED` のままとし、サンプリングの対象に含める。
-判定漏れしたエラーが間引かれる可能性を負うが、多弁なアプリケーションのノイズを抑えることを優先する。
+残る `UNSPECIFIED` はアクセスログ、スタックトレースの継続行、バナー出力など、元のログにレベル表記が存在しない行である。
+
+なお journald は systemd の `PRIORITY` を持つため、本文からの推測より確実な値が得られる。
+Alloy 側の relabel で `__journal_priority_keyword` を `journal_priority` ラベルとして残し、Collector はこれを最優先で採用する。
 
 ## オプトアウト
 
@@ -433,7 +442,9 @@ redact の指定漏れという事故が構造的に起きなくなる。
 
 - ~~**nebula アプリケーションが `LOG_LEVEL` 環境変数を参照するかは未確認である**~~
   → 解消。`backend/util/logger/logger.go` に `env:"LOG_LEVEL" envDefault:"debug"` と定義されていることをソースで確認した。既定値が DEBUG だったことも裏付けられた。
-- **ANSI エスケープ除去の正規表現は実データでの動作確認が必要である**。OTTL の `replace_pattern` は RE2 を使うため、`\x1b` の記法が期待通り解釈されるかを実際のログで確かめる。設定として妥当であることは `otelcol validate` で確認済みだが、実際に除去されるかは未検証である。
+- ~~**ANSI エスケープ除去の正規表現は実データでの動作確認が必要である**~~
+  → 解消。epgstation の `\x1b[32m[2026-08-04T09:10:05.106] [INFO] system - \x1b[39m` 形式が除去後に `[INFO]` として認識され、INFO に分類されることを実ログで確認した。
+- **Alloy から OTLP で届く Loki のラベルは、リソース属性ではなくログレコード属性に載る**。`otelcol.receiver.loki` の変換仕様による。Mackerel の画面で実データを確認して判明した。当初は `resource.attributes["unit"]` を参照しており、常に nil となって警告もエラーも出ないまま機能していなかった。同種の参照を追加するときは、必ず実データで載る場所を確認すること。
 - **β 期間中はデータ保持が保証されない**。評価期間中に Loki を縮小しない理由がこれにあたる。
 - **`supplementalGroups: [0]` で実際に Pod ログを読めるかは実機で確認する**。ファイルの権限からは読めると判断できるが、非 root での動作は実際に Collector を起動して確かめる。
 - **`mode: daemonset` は hostPort をノード IP に露出させる**。この Collector は Mackerel API キーを持つため、認証なしの受信口を LAN に開けない。`ports` で jaeger / zipkin / otlp-http を無効化し、`otlp` は `hostPort: 0` にした。Alloy からの接続は Service（`internalTrafficPolicy: Local`）経由で足りる。ポート宣言を消してもプロセスは Pod IP で listen したままである点は残る（クラスタ内からは到達可能）。

--- a/k8s/apps/grafana-alloy/config/config.alloy
+++ b/k8s/apps/grafana-alloy/config/config.alloy
@@ -55,6 +55,16 @@ loki.relabel "node_systemd_journal" {
 		action        = "replace"
 		target_label  = "unit"
 	}
+
+	// systemd の PRIORITY をキーワード表記
+	// (emerg / alert / crit / error / warning / notice / info / debug) で残す。
+	// Collector 側の severity 判定は、この値があれば本文からの推測より優先する。
+	// 取り得る値は 8 種類しかないため、Loki のストリーム数への影響は小さい。
+	rule {
+		source_labels = ["__journal_priority_keyword"]
+		action        = "replace"
+		target_label  = "journal_priority"
+	}
 }
 
 loki.source.journal "node_systemd_journal" {

--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -63,13 +63,13 @@ helmCharts:
               # systemd の unit を種にすることで、率を下げたときに unit 単位で
               # 採否が決まり、選ばれた unit のログは前後関係を保ったまま残る。
               #
-              # unit が OTLP 変換後にリソース属性として現れるかは
-              # otelcol.receiver.loki の変換仕様に依存し、journald が 1 行も
-              # 流れていない現状では実測できていない。取れなかった場合は固定値に
-              # 落ちるため、率を下げると journald 全体が全通過か全破棄の二択になる。
-              # 率を下げる前に、実際に unit が取れているかを確認すること。
-              - set(log.attributes["sample_key"], resource.attributes["unit"])
-                  where resource.attributes["unit"] != nil
+              # Alloy の otelcol.receiver.loki は Loki のラベルをログレコード属性に
+              # 載せる。リソース属性ではない。Mackerel の画面で実データを確認する
+              # までは resource.attributes を参照しており、unit が常に nil になって
+              # 種が固定値 "systemd" に落ちていた。この状態で率を下げると journald
+              # 全体が全通過か全破棄の二択になる。
+              - set(log.attributes["sample_key"], log.attributes["unit"])
+                  where log.attributes["unit"] != nil
               - set(log.attributes["sample_key"], "systemd")
                   where log.attributes["sample_key"] == nil
           transform/journald_service_name:
@@ -126,21 +126,119 @@ helmCharts:
               # map に変換することで、level の判定と Mackerel 画面での属性検索が効く。
               - set(log.body, ParseJSON(log.body))
                   where IsString(log.body) and IsMatch(log.body, "^\\s*\\{")
-              # JSON ログは level フィールドから判定する
-              - set(log.severity_number, SEVERITY_NUMBER_ERROR)
-                  where not IsString(log.body) and log.body["level"] == "error"
-              - set(log.severity_number, SEVERITY_NUMBER_WARN)
-                  where not IsString(log.body) and log.body["level"] == "warn"
+
+              # 以降はレベル表記を log.cache["level"] にいったん集約し、最後に
+              # まとめて severity へ変換する。判定の「どこを見るか」と「何レベルか」
+              # を分離することで、対応形式を増やしても変換部が肥大化しない。
+              # cache はログレコードごとに独立しており、前の行の値は残らない。
+
+              # journald は systemd の PRIORITY を持つ。本文からの推測より確実で
+              # あるため最優先で採用する。Alloy の relabel で journal_priority
+              # ラベルとして残しており、値は syslog のキーワード表記
+              # (emerg / alert / crit / error / warning / notice / info / debug) になる。
+              #
+              # Alloy の otelcol.receiver.loki は Loki のラベルをリソース属性では
+              # なくログレコード属性に載せる。どちらに載るかは Mackerel の画面で
+              # 実データを見て確認した。resource.attributes を参照すると nil 比較に
+              # なり、警告もエラーも出ないまま常に判定に失敗する。
+              - set(log.cache["level"], log.attributes["journal_priority"])
+                  where log.attributes["journal_priority"] != nil
+
+              # 構造化ログはレベルを持つキーから読む。キー名はアプリケーションに
+              # よって異なるため、よく使われるものを順に見る。
+              - set(log.cache["level"], log.body["level"])
+                  where log.cache["level"] == nil
+                    and not IsString(log.body) and log.body["level"] != nil
+              - set(log.cache["level"], log.body["severity"])
+                  where log.cache["level"] == nil
+                    and not IsString(log.body) and log.body["severity"] != nil
+              - set(log.cache["level"], log.body["lvl"])
+                  where log.cache["level"] == nil
+                    and not IsString(log.body) and log.body["lvl"] != nil
+
+              # テキストログは本文からレベル表記を切り出す。本文全体への部分一致は
+              # 使えない。"watch ended with error" のように、メッセージ中の単語に
+              # 引きずられて INFO のログを ERROR と誤判定するためである。
+              # 先頭 72 文字以内の、区切り文字に挟まれた表記だけを拾い、最も左に
+              # 現れたものを採用する。72 文字はタイムスタンプが最も長い形式
+              # (Aug  4 11:36:34 (1785810994.460354) danted[120236]: info:) を
+              # 収める幅として決めた。
+              #
+              # ExtractPatterns は一致しなかった名前付きグループも空文字で返す。
+              # 1 つの正規表現に複数のグループを持たせると空文字と未一致を区別
+              # できなくなるため、形式ごとに 1 グループの正規表現に分けている。
+
+              # klog (Kubernetes 系コンポーネント)。行頭の I0804 / E0803 形式。
+              - set(log.cache["match"],
+                    ExtractPatterns(log.body, "^(?P<level>[DIWEF])\\d{4}\\s"))
+                  where IsString(log.body)
+              - set(log.cache["level"], log.cache["match"]["level"])
+                  where IsString(log.body) and log.cache["match"]["level"] != nil
+              # telegraf。E! / W! / I! / D! の 1 文字表記。
+              - set(log.cache["match"],
+                    ExtractPatterns(log.body, "^.{0,72}?(?:^|\\s)(?P<level>[DIWEF])!\\s"))
+                  where IsString(log.body) and log.cache["level"] == nil
+              - set(log.cache["level"], log.cache["match"]["level"])
+                  where IsString(log.body) and log.cache["level"] == nil
+                    and log.cache["match"]["level"] != nil
+              # PostgreSQL の LOG:。LOG は一般的な英単語であり、大文字かつ直後が
+              # コロンのときだけレベル表記とみなす。ERROR / FATAL など他のレベルは
+              # 後続の汎用パターンで拾える。
+              - set(log.cache["match"],
+                    ExtractPatterns(log.body, "^.{0,72}?(?:^|\\s)(?P<level>LOG):"))
+                  where IsString(log.body) and log.cache["level"] == nil
+              - set(log.cache["level"], log.cache["match"]["level"])
+                  where IsString(log.body) and log.cache["level"] == nil
+                    and log.cache["match"]["level"] != nil
+              # 汎用。level=info / [INFO] / |INFO| / INFO: / タブ区切りの INFO など、
+              # 区切り文字に挟まれたレベル表記を拾う。長い綴りを先に並べているのは、
+              # RE2 の選択肢が左優先で、warn を先に置くと warning が warn として
+              # 切り出されてしまうためである。
+              - set(log.cache["match"],
+                    ExtractPatterns(log.body,
+                      "^.{0,72}?(?:^|[\\s\\[|,=])(?P<level>(?i:trace|trc|debug|dbg|warning|warn|wrn|information|info|inf|notice|error|err|fatal|ftl|panic|pnc|critical|crit|alert|emerg))(?:[\\s\\]|:!,=]|$)"))
+                  where IsString(log.body) and log.cache["level"] == nil
+              - set(log.cache["level"], log.cache["match"]["level"])
+                  where IsString(log.body) and log.cache["level"] == nil
+                    and log.cache["match"]["level"] != nil
+
+              # 表記ゆれを小文字に寄せてから変換する
+              - set(log.cache["level"], ConvertCase(log.cache["level"], "lower"))
+                  where log.cache["level"] != nil
+
+              # severity_number と severity_text の双方を設定する。Mackerel の画面が
+              # どちらを表示に使うかは非公開であり、片方だけでは UNSPECIFIED の
+              # ままになる可能性があるため。
+              - set(log.severity_number, SEVERITY_NUMBER_TRACE)
+                  where IsMatch(log.cache["level"], "^(trace|trc)$")
+              - set(log.severity_text, "TRACE")
+                  where IsMatch(log.cache["level"], "^(trace|trc)$")
+              - set(log.severity_number, SEVERITY_NUMBER_DEBUG)
+                  where IsMatch(log.cache["level"], "^(debug|dbg|d)$")
+              - set(log.severity_text, "DEBUG")
+                  where IsMatch(log.cache["level"], "^(debug|dbg|d)$")
               - set(log.severity_number, SEVERITY_NUMBER_INFO)
-                  where not IsString(log.body) and log.body["level"] == "info"
-              # テキストログは本文から推定する。zerolog の ERR / WRN 表記にも対応する
-              - set(log.severity_number, SEVERITY_NUMBER_ERROR)
-                  where IsString(log.body)
-                    and IsMatch(log.body, "(?i)\\b(err|error|fatal|panic)\\b")
+                  where IsMatch(log.cache["level"], "^(info|inf|information|i|log)$")
+              - set(log.severity_text, "INFO")
+                  where IsMatch(log.cache["level"], "^(info|inf|information|i|log)$")
+              # syslog の notice に対応する severity は OpenTelemetry には無い。
+              # info より一段高い INFO2 に寄せる。
+              - set(log.severity_number, SEVERITY_NUMBER_INFO2)
+                  where IsMatch(log.cache["level"], "^notice$")
+              - set(log.severity_text, "NOTICE")
+                  where IsMatch(log.cache["level"], "^notice$")
               - set(log.severity_number, SEVERITY_NUMBER_WARN)
-                  where IsString(log.body)
-                    and log.severity_number == SEVERITY_NUMBER_UNSPECIFIED
-                    and IsMatch(log.body, "(?i)\\b(wrn|warn|warning)\\b")
+                  where IsMatch(log.cache["level"], "^(warning|warn|wrn|w)$")
+              - set(log.severity_text, "WARN")
+                  where IsMatch(log.cache["level"], "^(warning|warn|wrn|w)$")
+              - set(log.severity_number, SEVERITY_NUMBER_ERROR)
+                  where IsMatch(log.cache["level"], "^(error|err|e)$")
+              - set(log.severity_text, "ERROR")
+                  where IsMatch(log.cache["level"], "^(error|err|e)$")
+              - set(log.severity_number, SEVERITY_NUMBER_FATAL)
+                  where IsMatch(log.cache["level"], "^(fatal|ftl|panic|pnc|critical|crit|alert|emerg|f)$")
+              - set(log.severity_text, "FATAL")
+                  where IsMatch(log.cache["level"], "^(fatal|ftl|panic|pnc|critical|crit|alert|emerg|f)$")
         receivers:
           filelog:
             # preset の includeCollectorLogs は otel-agent 自身の分しか除外しない。


### PR DESCRIPTION
## 背景

Mackerel のログ機能に Pod のログを送り始めたが、ログレベルが認識されず `UNSPECIFIED` になるログが大量に発生していた。

実クラスタの全 namespace から収集したログ 1299 行を、稼働中と同じ `otel/opentelemetry-collector-k8s:0.156.0` に通して計測したところ、**1094 行 (84.2%) が `UNSPECIFIED`** だった。

## 原因

3 つある。いずれも `transform/severity` の判定ロジックに由来する。

### 1. INFO と DEBUG の判定ルールが存在しなかった

既存のルールは ERROR と WARN しか設定していなかった。クラスタのログの大半を占める INFO と DEBUG は、どのルールにも当たらないまま素通りしていた。これが `UNSPECIFIED` の大部分を占める。

### 2. JSON ログの level 比較が小文字固定だった

`log.body["level"] == "error"` のように小文字で比較していたが、実データには大文字で出力するアプリケーションが多数ある。

```
{"time":"...","level":"INFO","msg":"request","status":200,...}   # nebula/backend
{"time":"...","level":"INFO","msg":"login successful",...}       # argo-cd/dex
{"time":"...","level":"WARN","msg":"event channel closed",...}   # watch-k8s-events
```

### 3. 本文全体への部分一致で判定していたため誤検知していた

`IsMatch(log.body, "(?i)\b(err|error|fatal|panic)\b")` は本文のどこに単語があっても一致する。その結果、ERROR と判定された 86 件の大半が誤判定だった。

| 実際のレベル | 本文（抜粋） | 旧判定 |
| --- | --- | --- |
| INFO | `INFO controller-runtime.cache Warning: watch ended with error` | ERROR |
| INFO | `I0801 ... "Warning: watch ended with error" err="..."` | ERROR |
| INFO | `danted[120236]: info: pass(1): ... local client error (Connection reset by peer)` | ERROR |
| WARN | `level=warn msg="tailer stopped; will retry" ... err="..."` | ERROR |

判定漏れと誤判定が同時に起きており、レベルによる絞り込みもサンプリングの優先度付与も信用できない状態だった。

## 変更内容

### レベル表記の抽出と変換を分離する

「どこを見るか」と「何レベルか」を分け、レベル表記をいったん `log.cache["level"]` に集約してから `severity_number` と `severity_text` に変換する。対応形式を増やしても変換部が肥大化しない。

参照順は次のとおり。先に決まったものを優先する。

1. journald の `journal_priority`（systemd の PRIORITY 由来の確定値）
2. 構造化ログの `level` / `severity` / `lvl` キー
3. テキストログの本文からの切り出し

### テキストログは位置と綴りの両方を規定する

本文全体への部分一致をやめ、**先頭 72 文字以内で、区切り文字に挟まれたレベル表記のうち最も左に現れたもの**だけを切り出す。

- 位置を先頭 72 文字に限る。72 文字はタイムスタンプが最も長い形式（`Aug  4 11:36:34 (1785810994.460354) danted[120236]: info:`）を収める幅として決めた
- 区切り文字（空白・`[`・`|`・`,`・`=`）に挟まれていることを要求する。これにより `Detecting IPv6 via cloudflare.trace` の `trace` のような語を拾わない
- 最も左に現れたものを採る。`INFO ... watch ended with error` では先に現れる `INFO` が勝つ

klog（`I0804` / `E0803`）、telegraf（`E!` / `W!`）、PostgreSQL の `LOG:` は綴りの形が違うため個別のパターンで拾う。

`ExtractPatterns` は一致しなかった名前付きグループも空文字で返すため、1 つの正規表現に複数のグループを持たせると空文字と未一致を区別できない。形式ごとに 1 グループの正規表現に分けている。

### journald は systemd の PRIORITY を使う

Alloy の relabel で `__journal_priority_keyword` を `journal_priority` ラベルとして残す。値は `emerg / alert / crit / error / warning / notice / info / debug` のいずれかであり、本文からの推測ではなく systemd が付けた確定値を使える。

### サンプリングの種の参照先を修正する

Alloy から OTLP で届く Loki のラベルは、**リソース属性ではなくログレコード属性**に載ることが実データで判明した。`transform/journald_sampling` が `resource.attributes["unit"]` を参照していたため常に nil となり、サンプリングの種が固定値 `"systemd"` に落ちていた。この状態でサンプリング率を下げると、journald 全体が全通過か全破棄の二択になる。参照先を `log.attributes["unit"]` に修正した。

設計書にも「率を下げる前に、実際に unit が取れているかを確認すること」と記載していた未検証事項であり、あわせて解消した。

## 検証

### 判定ロジックの計測

実クラスタの全 namespace から収集したログを、稼働中と同じ `otel/opentelemetry-collector-k8s:0.156.0` に通して計測した。

| 対象 | 修正前 | 修正後 |
| --- | --- | --- |
| Pod ログ | `UNSPECIFIED` 1094 / 1299 (84.2%) | **355 / 1299 (27.3%)** |
| journald（本文推測のみ） | `UNSPECIFIED` 1389 / 1500 (92.6%) | **523 / 1500 (34.9%)** |
| journald（PRIORITY 採用後） | — | **`UNSPECIFIED` 0 件** |

残った `UNSPECIFIED` は、アクセスログ・スタックトレースの継続行・バナー出力など、**元のログにレベル表記が存在しない行**である。

誤検知が解消したことを、修正前に誤判定していた行を名指しで確認した。

| 本文（抜粋） | 修正前 | 修正後 |
| --- | --- | --- |
| `INFO controller-runtime.cache Warning: watch ended with error` | ERROR | **INFO** |
| `I0801 ... "Warning: watch ended with error"` | ERROR | **INFO** |
| `danted[120236]: info: ... local client error` | ERROR | **INFO** |
| `level=warn msg="tailer stopped; will retry" ... err="..."` | ERROR | **WARN** |

### 実環境での確認

ArgoCD の自動同期を一時停止し、ビルドしたマニフェストをクラスタに適用して Mackerel の画面で確認した。確認後、同期設定は元に戻している。

- OTTL の statement 実行失敗は 0 件
- Pod ログのレベルが表示されること（`nebula / backend` の JSON ログが `INFO` として分類される）
- journald のレベルが表示されること（100 行中 `UNSPECIFIED` 0 件、内訳は INFO 95 / ERROR 5）
- サンプリングの種が unit 単位になること（`sample_key` が `kubelet.service` / `crio.service` / `init.scope` / `tailscaled.service` / `systemd-networkd.service` に分かれた。修正前は全件 `systemd`）
- 検証用の Pod からレベル表記を含む行を出力し、`NOTICE` が `INFO` として表示され、`INFO` で絞り込んだ検索にも含まれることを確認した。`TRACE` と `FATAL` はそのまま表示される

syslog の `notice` に対応する severity は OpenTelemetry に無いため `INFO2` に寄せているが、Mackerel の画面では `INFO` として扱われる。ログレベルのフィルタから漏れることはない。

### 静的検査

- `go run ./cmd/build-manifests`（kustomize build）: 153 root すべて成功
- `otelcol validate`: 生成された Collector 設定に対して成功
- `kube-linter`: 変更対象への指摘 0 件（master と同数）

## 動物界における比擬

シジュウカラは鳴き声を組み合わせて意味を作る。「ピーツピ」で警戒を促し、「ヂヂヂヂ」で集合を促し、この順で並べたときだけ「警戒しながら集まれ」になる。順序を入れ替えると、同じ音素を使っていても仲間は反応しない。意味は音そのものではなく、音が現れる位置に宿っている。

修正前のログレベル判定は、この位置を見ていなかった。文のどこかに「エラー」という音素が混じっていれば警戒声とみなす、という聞き方をしていた。だから「エラーが起きたという話を、平常時の報告として述べている」文までも警戒声として拾ってしまう。仲間が落ち着いて状況を伝えているだけなのに、群れ全体が飛び立つようなものである。

修正後は、鳴き始めの一節だけを聞き、そこに区切りを持って現れた音素だけを意味として受け取る。後続の本文に同じ音が混じっていても、それは警戒ではなく叙述として聞き流す。

journald の PRIORITY を優先する変更は、これとは別の性質を持つ。ミツバチの尻振りダンスは、蜜源の方角と距離を鳴き声ではなく身体の角度と時間で直接示す。聞き手が言葉を解釈する余地がない代わりに、誤解も生じない。systemd が付ける PRIORITY はこの角度にあたる。本文をどう読むかという解釈の問題を、そもそも発生させない。
