### PR TITLE
feat(nebula): /mcp を backend にルーティングする

### DIFF
--- a/k8s/apps/nebula/resources/ingress.yaml
+++ b/k8s/apps/nebula/resources/ingress.yaml
@@ -23,8 +23,16 @@ spec:
           namespace: authentik
           port: http
 
+    # このルールに middleware を付けないのは意図的で、アプリケーション側で自前の
+    # 認証・認可を行う経路をまとめている。/mcp はブラウザ以外のクライアントが
+    # Bearer トークンで叩く API であり、対話的なログインを前提とする forward-auth を
+    # 通すと SSO へリダイレクトされて到達できなくなる。
+    #
+    # /mcp を PathPrefix にすると frontend の別のパスまで巻き込むため、完全一致と
+    # 配下だけを対象にする。Traefik の PathPrefix がセグメント境界を見るかどうかに
+    # 依存しない書き方でもある。
     - kind: Rule
-      match: Host(`nebula.starry.blue`) && (PathPrefix(`/api`) || PathPrefix(`/oauth`) || PathPrefix(`/.well-known`)) && !Path(`/oauth/authorize`)
+      match: Host(`nebula.starry.blue`) && (PathPrefix(`/api`) || PathPrefix(`/oauth`) || PathPrefix(`/.well-known`) || Path(`/mcp`) || PathPrefix(`/mcp/`)) && !Path(`/oauth/authorize`)
       priority: 20
       services:
         - name: backend


### PR DESCRIPTION
nebula に `/mcp` エンドポイントを追加したため、Ingress を追従させる。

## 解決する問題

`/mcp` は現状どのルールにもマッチせず、priority 10 の catch-all に落ちて frontend へ転送される。さらにそのルールには `forward-auth-authentik` middleware が付いているため、リクエストは Authentik の SSO へリダイレクトされる。

この経路はアプリケーション層で Bearer トークンによる認証を行う API であり、**対話的なログインを前提とする forward-auth を通してはならない**。クライアントはブラウザではないため、SSO へリダイレクトされた時点で到達できなくなる。

## 変更内容

priority 20 の backend ルールに `/mcp` を追加する。このルールは middleware を持たないため、Authentik の対話的ログインを経由しない。

```diff
-      match: Host(`nebula.starry.blue`) && (PathPrefix(`/api`) || PathPrefix(`/oauth`) || PathPrefix(`/.well-known`)) && !Path(`/oauth/authorize`)
+      match: Host(`nebula.starry.blue`) && (PathPrefix(`/api`) || PathPrefix(`/oauth`) || PathPrefix(`/.well-known`) || Path(`/mcp`) || PathPrefix(`/mcp/`)) && !Path(`/oauth/authorize`)
```

`/api` と `/oauth` が既に同じ扱いになっており、いずれもアプリケーション側で自前の認証・認可を行っている。`/mcp` もそれに倣う。

### `Path` と `PathPrefix` を使い分けた理由

`PathPrefix(`/mcp`)` にすると、将来 frontend に `/mcp` で始まる別のパスが生えたときに巻き込んで backend に転送してしまう。完全一致 `Path(`/mcp`)` と配下 `PathPrefix(`/mcp/`)` に限定した。

Traefik v3 の `PathPrefix` がセグメント境界を見るかどうかに依存しない書き方でもある。

### `/.well-known` は変更不要

このエンドポイントに対応するディスカバリ文書は `/.well-known` 配下に置かれるが、既存の `PathPrefix(`/.well-known`)` に含まれるため追加作業は要らない。

## 検証

```console
$ kubectl kustomize --enable-helm k8s/apps/nebula | grep -A 6 'priority: 20'
```

```yaml
  - kind: Rule
    match: Host(`nebula.starry.blue`) && (PathPrefix(`/api`) || PathPrefix(`/oauth`)
      || PathPrefix(`/.well-known`) || Path(`/mcp`) || PathPrefix(`/mcp/`)) && !Path(`/oauth/authorize`)
    priority: 20
    services:
    - name: backend
      port: http
```

`pnpm eslint` exit=0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)