### PR TITLE
fix(n8n): probe を /healthz/readiness に向けて DB 断からの自己修復を効かせる

### DIFF
--- a/k8s/apps/n8n/kustomization.yaml
+++ b/k8s/apps/n8n/kustomization.yaml
@@ -59,24 +59,24 @@ helmCharts:
         # /rest/login が 503 Database is not ready! を返し続けた。
         # DB 接続まで見る /healthz/readiness を向けて、Kubernetes 側から検知・自己修復できるようにする。
         livenessProbe:
+          # PostgreSQL の再起動やメンテナンスで一時的に落ちただけで再起動ループに入らないよう、
+          # 5 分 (10s × 30) の猶予を持たせる。チャート既定の failureThreshold と同値。
+          failureThreshold: 30
           httpGet:
             path: /healthz/readiness
             port: http
-          # PostgreSQL の再起動やメンテナンスで一時的に落ちただけで再起動ループに入らないよう、
-          # 5 分 (10s × 30) の猶予を持たせる。チャート既定の failureThreshold と同値。
           periodSeconds: 10
-          failureThreshold: 30
         persistence:
           enabled: true
           existingClaim: n8n-data
           type: existing
         readinessProbe:
+          # 疎通不能なうちにリクエストを流し込まないよう、readiness は liveness より早く落とす。
+          failureThreshold: 3
           httpGet:
             path: /healthz/readiness
             port: http
-          # 疎通不能なうちにリクエストを流し込まないよう、readiness は liveness より早く落とす。
           periodSeconds: 10
-          failureThreshold: 3
       # TODO: worker を分離
       # worker:
       #   enabled: true

--- a/k8s/apps/n8n/kustomization.yaml
+++ b/k8s/apps/n8n/kustomization.yaml
@@ -53,10 +53,30 @@ helmCharts:
               secretKeyRef:
                 name: n8n-secret
                 key: license_activation_key
+        # チャート既定は liveness / readiness とも /healthz を向いているが、これはプロセスの生存しか
+        # 見ないため、DB 接続が切れて n8n が自力で復帰できなくなっても Pod は Ready のまま放置される。
+        # 実際 2026-08-08 に PostgreSQL の再起動をきっかけに n8n の再接続機構が発火せず、
+        # /rest/login が 503 Database is not ready! を返し続けた。
+        # DB 接続まで見る /healthz/readiness を向けて、Kubernetes 側から検知・自己修復できるようにする。
+        livenessProbe:
+          httpGet:
+            path: /healthz/readiness
+            port: http
+          # PostgreSQL の再起動やメンテナンスで一時的に落ちただけで再起動ループに入らないよう、
+          # 5 分 (10s × 30) の猶予を持たせる。チャート既定の failureThreshold と同値。
+          periodSeconds: 10
+          failureThreshold: 30
         persistence:
           enabled: true
           existingClaim: n8n-data
           type: existing
+        readinessProbe:
+          httpGet:
+            path: /healthz/readiness
+            port: http
+          # 疎通不能なうちにリクエストを流し込まないよう、readiness は liveness より早く落とす。
+          periodSeconds: 10
+          failureThreshold: 3
       # TODO: worker を分離
       # worker:
       #   enabled: true


### PR DESCRIPTION
## 背景

2026-08-08 14:51 (JST) に PostgreSQL (`postgresql-0`) が再起動したあと、n8n の UI が 503 を返し続けた。

```json
{ "code": 503, "message": "Database is not ready!" }
```

PostgreSQL 自体は 5 秒で復帰しており、Service の Endpoint も正常だった。落ちていたのは **n8n プロセス内部の DB 接続状態フラグ**だけである。

n8n には ping 監視 + 再接続機構があるが、同日 14:27 の断と 14:51 の断でログの挙動が決定的に異なっていた。

| ログ | 14:27 の断 | 14:51 の断 |
| --- | --- | --- |
| `Database ping failed (n/3)` | 3 回出力 | **一度も出ていない** |
| `Triggering database connection recovery` | 発火 | 発火せず |
| `Database connection recovered` | `after 5 attempt(s) in 15115ms` | 出ていない |

2 回目の断では監視ループが機能せず、リカバリが一度も発火しないまま not-ready で固着した。n8n 側の不具合と見られるが、本 PR ではそこには踏み込まない。

問題は **それが人手介入なしに直らないこと**である。チャート既定では liveness / readiness とも `/healthz` を向いており、これはプロセスの生存しか見ない。

```
/healthz             200  {"status":"ok"}                                    ← 常に 200
/healthz/readiness   503  {"status":"error"}                                 ← DB を見ている
/rest/login          503  {"code":503,"message":"Database is not ready!"}
```

結果、Pod は `1/1 Running` のまま、Kubernetes は再起動も Service からの切り離しも行わなかった。

## 変更内容

両プローブを DB 接続まで見る `/healthz/readiness` に向ける。

- **livenessProbe**: `failureThreshold: 30`, `periodSeconds: 10` → 5 分の猶予。PostgreSQL の再起動やメンテナンス程度で再起動ループに入らせない (今回の断は約 40 秒だった)
- **readinessProbe**: `failureThreshold: 3`, `periodSeconds: 10` → 30 秒でトラフィックを止める

liveness を DB 依存にするのは一般にカスケード障害を招くアンチパターンだが、n8n は単一レプリカで DB なしでは何もできず、かつ本件のように自力復帰できないケースが実在するため、十分な猶予を設けたうえで採用する。

## 検証

### 生成マニフェストの差分

`kustomize build --enable-helm k8s/apps/n8n` の出力差分は n8n Deployment のプローブのみ (`checksum/config` は付随的な変化)。

```diff
           failureThreshold: 30
           httpGet:
-            path: /healthz
+            path: /healthz/readiness
             port: http
           periodSeconds: 10
```

### `go run ./cmd/build-manifests`

```
✅ kustomize build succeeded  (全ルート、EXIT=0)
```

### kube-linter

指摘数は変更前後で不変。既存の 23 件はいずれも helm test 用 Pod (`n8n-test-connection`) と PostgreSQL チャート由来で、本変更とは無関係。

```
master:  found 23 lint errors
branch:  found 23 lint errors
```

### 本番の復旧確認 (本 PR 適用前に手動再起動で実施)

`kubectl -n n8n rollout restart deploy/n8n` により復旧済み。

| エンドポイント | before (05:57:03 UTC) | after (05:59:06 UTC) |
| --- | --- | --- |
| `/healthz` | 200 `{"status":"ok"}` | 200 `{"status":"ok"}` |
| `/healthz/readiness` | **503** `{"status":"error"}` | **200** `{"status":"ok"}` |
| `/rest/login` | **503** `Database is not ready!` | **401** `Unauthorized` |

`/rest/login` の 401 は DB に到達して認証処理が走った正常応答。ワークフロー 4 件もすべて再アクティベートされた。

## 未検証事項

- 本 PR のプローブ設定が **実際の DB 断で期待どおり自己修復するか**は、本番で DB を落とす必要があるため未検証。マニフェスト生成までの確認に留まる。
- 14:51 の断で n8n の ping 監視ループが動かなかった理由は、n8n のソースを追っていないため未特定。
- PostgreSQL が `database system was not properly shut down` で終了しており graceful shutdown ができていない件は本 PR のスコープ外。