### PR TITLE
fix(postgresql): preStop で fast shutdown してクラッシュリカバリを避ける

### DIFF
--- a/k8s/apps/headlessx/kustomization.yaml
+++ b/k8s/apps/headlessx/kustomization.yaml
@@ -27,6 +27,21 @@ helmCharts:
         extraEnvVars:
           - name: TZ
             value: Asia/Tokyo
+        # Bitnami の PostgreSQL イメージは STOPSIGNAL を設定しておらず、PID 1 の postgres は
+        # SIGTERM を smart shutdown (既存クライアントが自ら切断するまで待つ) と解釈する。
+        # アプリがコネクションプールを保持し続けるので待機が終わらず、
+        # terminationGracePeriodSeconds 満了で SIGKILL され、毎回クラッシュリカバリになる。
+        # 公式 postgres イメージは STOPSIGNAL SIGINT でこれを回避しているが、
+        # Kubernetes 1.35 時点で stopSignal は ContainerStopSignals が alpha かつ無効のため使えない。
+        # そこで preStop で明示的に fast shutdown する。
+        lifecycleHooks:
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                # terminationGracePeriodSeconds (既定 30 秒) を超えないよう -t で頭打ちにする
+                - pg_ctl stop -D "$PGDATA" -m fast -w -t 25
         persistence:
           existingClaim: headlessx-postgresql-data
         resourcesPreset: nano

--- a/k8s/apps/n8n/kustomization.yaml
+++ b/k8s/apps/n8n/kustomization.yaml
@@ -95,6 +95,21 @@ helmCharts:
         extraEnvVars:
           - name: TZ
             value: Asia/Tokyo
+        # Bitnami の PostgreSQL イメージは STOPSIGNAL を設定しておらず、PID 1 の postgres は
+        # SIGTERM を smart shutdown (既存クライアントが自ら切断するまで待つ) と解釈する。
+        # n8n はコネクションプールを保持し続けるので待機が終わらず、
+        # terminationGracePeriodSeconds 満了で SIGKILL され、毎回クラッシュリカバリになる。
+        # 公式 postgres イメージは STOPSIGNAL SIGINT でこれを回避しているが、
+        # Kubernetes 1.35 時点で stopSignal は ContainerStopSignals が alpha かつ無効のため使えない。
+        # そこで preStop で明示的に fast shutdown する。
+        lifecycleHooks:
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                # terminationGracePeriodSeconds (既定 30 秒) を超えないよう -t で頭打ちにする
+                - pg_ctl stop -D "$PGDATA" -m fast -w -t 25
         persistence:
           existingClaim: n8n-postgresql-data
         resourcesPreset: nano

--- a/k8s/apps/stay-tuned/kustomization.yaml
+++ b/k8s/apps/stay-tuned/kustomization.yaml
@@ -27,6 +27,21 @@ helmCharts:
         extraEnvVars:
           - name: TZ
             value: Asia/Tokyo
+        # Bitnami の PostgreSQL イメージは STOPSIGNAL を設定しておらず、PID 1 の postgres は
+        # SIGTERM を smart shutdown (既存クライアントが自ら切断するまで待つ) と解釈する。
+        # アプリがコネクションプールを保持し続けるので待機が終わらず、
+        # terminationGracePeriodSeconds 満了で SIGKILL され、毎回クラッシュリカバリになる。
+        # 公式 postgres イメージは STOPSIGNAL SIGINT でこれを回避しているが、
+        # Kubernetes 1.35 時点で stopSignal は ContainerStopSignals が alpha かつ無効のため使えない。
+        # そこで preStop で明示的に fast shutdown する。
+        lifecycleHooks:
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                # terminationGracePeriodSeconds (既定 30 秒) を超えないよう -t で頭打ちにする
+                - pg_ctl stop -D "$PGDATA" -m fast -w -t 25
         persistence:
           existingClaim: stay-tuned-postgresql-data
         resourcesPreset: nano


### PR DESCRIPTION
## 背景

#9875 の調査中に発見。PostgreSQL の Pod を再起動するたび、起動ログに毎回これが出ていた。

```
LOG:  database system was interrupted; last known up at 2026-08-08 05:32:12 GMT
LOG:  database system was not properly shut down; automatic recovery in progress
LOG:  redo starts at 0/64A3BBE8
```

つまり毎回クラッシュリカバリからの起動になっている。

## 原因

Bitnami の PostgreSQL イメージは `STOPSIGNAL` を設定しておらず、`run.sh` が `exec postgres` するため **PID 1 = postgres**、受け取るシグナルは既定の SIGTERM になる。

```console
$ docker inspect docker.io/bitnamilegacy/postgresql:17.6.0-debian-12-r4 --format '{{json .Config}}' | jq '{StopSignal, Entrypoint, Cmd}'
{
  "StopSignal": null,
  "Entrypoint": ["/opt/bitnami/scripts/postgresql/entrypoint.sh"],
  "Cmd": ["/opt/bitnami/scripts/postgresql/run.sh"]
}
```

PostgreSQL にとって SIGTERM は **Smart Shutdown** = 既存クライアントが自ら切断するまで待つ、を意味する。アプリ側がコネクションプールを保持し続けるので待機は終わらず、`terminationGracePeriodSeconds` (既定 30 秒) 満了で SIGKILL される。

公式 `postgres` イメージは Dockerfile に `STOPSIGNAL SIGINT` を明記してこれを回避しているが、Bitnami にはそれがない。

### ローカルでの再現

接続を 1 本張った状態で `docker stop -t 30` (K8s の grace period 相当) した結果。

```console
$ time docker stop -t 30 pgtest
docker stop -t 30 pgtest  0.01s user 0.00s system 0% cpu 30.314 total

$ docker logs pgtest | grep -i shutdown
2026-08-08 06:05:53.475 GMT [1] LOG:  received smart shutdown request
```

`received smart shutdown request` の先に進まず、30 秒フルに待って SIGKILL されている。再起動すると本番と同じログが出る。

```console
$ docker start pgtest && docker logs pgtest | grep -E 'not properly|redo'
LOG:  database system was not properly shut down; automatic recovery in progress
LOG:  redo starts at 0/14E4E70
```

## 検討した手段

### ❌ `lifecycle.stopSignal: SIGINT` (KEP-4960)

最も素直だが**使えない**。クラスタは v1.35.1 だが、この feature gate はまだ alpha かつ無効。

```console
$ kubectl get --raw /metrics | grep ContainerStopSignals
kubernetes_feature_enabled{name="ContainerStopSignals",stage="ALPHA"} 0
```

厄介なのは **API サーバーがエラーを返さず無言でフィールドを捨てる**こと。マニフェスト上は設定できているように見える。

```console
$ kubectl -n n8n apply --dry-run=server -f sts.yaml -o json | jq '.spec.template.spec.containers[0].lifecycle'
null        # ← 送信時は {"stopSignal": "SIGINT"} だった
```

`spec.os.name: linux` を併記しても同じく破棄された。

### ✅ preStop フックで明示的に fast shutdown

採用。チャートの `primary.lifecycleHooks` で表現でき、feature gate に依存しない。

## 変更内容

```yaml
lifecycleHooks:
  preStop:
    exec:
      command:
        - /bin/sh
        - -c
        - pg_ctl stop -D "$PGDATA" -m fast -w -t 25
```

`$PGDATA` はチャートが `/bitnami/postgresql/data` を設定済み。`-t 25` は `terminationGracePeriodSeconds` (30 秒) を超えないための頭打ち。

### 対象範囲

`postgresql` チャートを使う 5 アプリのうち、Bitnami イメージを使う 3 つのみが対象。

| アプリ | イメージ | STOPSIGNAL | 対応 |
| --- | --- | --- | --- |
| n8n | `bitnamilegacy/postgresql` | 未設定 (= SIGTERM) | ✅ 本 PR で修正 |
| headlessx | `bitnamilegacy/postgresql` | 未設定 (= SIGTERM) | ✅ 本 PR で修正 |
| stay-tuned | `bitnamilegacy/postgresql` | 未設定 (= SIGTERM) | ✅ 本 PR で修正 |
| nebula | `ghcr.io/slashnephy/nebula-postgres` | `SIGINT` | 対象外 |
| immich | `ghcr.io/immich-app/postgres` | `SIGINT` | 対象外 |

nebula と immich は公式 `postgres` 派生のため `STOPSIGNAL SIGINT` を継承済みで、この問題は起きない。

## 検証

### preStop コマンドの動作 (本番同等の制約下)

非 root (uid 1001) / read-only rootfs / 接続保持ありの条件で実行。

```console
$ docker exec pgtest3 sh -c 'pg_ctl stop -D "$PGDATA" -m fast -w -t 25'
waiting for server to shut down....
所要秒数: 0

$ docker logs pgtest3 | grep -iE 'shutdown|shut down'
LOG:  received fast shutdown request
LOG:  checkpoint starting: shutdown immediate
LOG:  database system is shut down
```

**30 秒 → 1 秒未満**に短縮され、`database system is shut down` でクリーンに終了している。再起動時もクラッシュリカバリが消えた。

```console
$ docker start pgtest3 && docker logs pgtest3 | grep -E 'not properly|was shut down at'
LOG:  database system was shut down at 2026-08-08 06:13:32 GMT     # ← 正常終了扱い
```

| | 修正前 (SIGTERM) | 修正後 (preStop) |
| --- | --- | --- |
| 停止所要時間 | 30 秒 (grace period 満了 → SIGKILL) | 1 秒未満 |
| 停止時ログ | `received smart shutdown request` で停止 | `database system is shut down` まで到達 |
| 次回起動時 | `not properly shut down; automatic recovery in progress` | `database system was shut down at ...` |

### API サーバーが受理することの確認

`stopSignal` と違い、preStop は破棄されずに残る。

```console
$ kubectl -n n8n apply --dry-run=server -f sts.yaml -o json | jq -c '.spec.template.spec.containers[0].lifecycle'
{"preStop":{"exec":{"command":["/bin/sh","-c","pg_ctl stop -D \"$PGDATA\" -m fast -w -t 25"]}}}
```

### 生成マニフェスト差分

3 アプリとも preStop の追加のみ。他のフィールドに影響なし。

```diff
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_ctl stop -D "$PGDATA" -m fast -w -t 25
```

### `go run ./cmd/build-manifests`

```
153 ルート全て ✅ kustomize build succeeded / EXIT=0
```

### kube-linter

指摘数は 3 アプリとも変更前後で不変。

```
n8n          master: found 23 lint errors   branch: found 23 lint errors
headlessx    master: found 12 lint errors   branch: found 12 lint errors
stay-tuned   master: found 17 lint errors   branch: found 17 lint errors
```

## 未検証事項

- **実クラスタでの preStop 発火は未検証。** 本番 Pod を落とす必要があるため、ローカル Docker での同等条件の再現とサーバー dry-run による受理確認に留めている。マージ後に PostgreSQL を再起動した際、起動ログに `database system was shut down at ...` が出れば期待どおり。
- headlessx / stay-tuned は現クラスタに StatefulSet が存在せず、`kustomize build` による生成物の確認のみ。