### PR TITLE
fix(kubeclarity): PostgreSQL を bitnamilegacy に固定して pull 不可を解消する

### DIFF
--- a/k8s/apps/kubeclarity/kustomization.yaml
+++ b/k8s/apps/kubeclarity/kustomization.yaml
@@ -2,6 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeclarity
 
+images:
+  # Bitnami は 2025-08 にバージョン固定タグを有償枠へ移したため、チャート既定の
+  # docker.io/bitnami/postgresql:14.6.0-debian-11-r31 は既に pull できない。
+  # 現在はノードのイメージキャッシュで動いているだけで、再スケジュールされると起動できない。
+  # 無償でバージョンを固定できるのは凍結済みの bitnamilegacy だけなので、そこに固定する。
+  - name: docker.io/bitnami/postgresql
+    newName: docker.io/bitnamilegacy/postgresql
+    newTag: 14.6.0-debian-11-r31
+
 helmCharts:
   - name: kubeclarity
     releaseName: kubeclarity


### PR DESCRIPTION
## 背景

#9876 のレビュー中、クラスタ内の PostgreSQL Pod を実際に確認していて発見。`k8s/apps/*/kustomization.yaml` のチャート名だけで検索していたため、sub-chart として PostgreSQL を持つ kubeclarity が漏れていた。

チャート既定の `docker.io/bitnami/postgresql:14.6.0-debian-11-r31` は、Bitnami が 2025-08 にバージョン固定タグを有償枠へ移したことで **既に pull できない**。

```console
$ docker manifest inspect docker.io/bitnami/postgresql:14.6.0-debian-11-r31
❌ pull 不可 (レジストリから消滅)

$ docker manifest inspect docker.io/bitnamilegacy/postgresql:14.6.0-debian-11-r31
✅ 取得可能
```

現在はノードのイメージキャッシュで動いているだけで、再スケジュールされた時点で ImagePullBackOff になる。

```console
$ kubectl -n kubeclarity get sts kubeclarity-kubeclarity-postgresql -o jsonpath='{.spec.template.spec.containers[0].image}'
docker.io/bitnami/postgresql:14.6.0-debian-11-r31
```

## 変更内容

他アプリ (#9869) と同じ方針で、`images:` による差し替えを追加する。PostgreSQL のバージョンは動かさない。

```yaml
images:
  - name: docker.io/bitnami/postgresql
    newName: docker.io/bitnamilegacy/postgresql
    newTag: 14.6.0-debian-11-r31
```

StatefulSet と Deployment の両方が同じイメージを参照しており、どちらも解消される。

## 検証

### 生成マニフェスト差分

```diff
-        image: docker.io/bitnami/postgresql:14.6.0-debian-11-r31
+        image: docker.io/bitnamilegacy/postgresql:14.6.0-debian-11-r31
```

(2 箇所: `StatefulSet/kubeclarity-kubeclarity-postgresql` と `Deployment/kubeclarity-kubeclarity`)

差分にはもう 1 箇所 `initContainers: null` → `initContainers: []` が出るが、これは API 上等価で、後述の server-side dry-run では差分として現れない。

### API サーバーとの実差分 (server-side dry-run)

image の 1 行のみ。

```console
$ kubectl -n kubeclarity diff -f sts.yaml
-        image: docker.io/bitnami/postgresql:14.6.0-debian-11-r31
+        image: docker.io/bitnamilegacy/postgresql:14.6.0-debian-11-r31
```

### `go run ./cmd/build-manifests`

```
EXIT=0
```

### ESLint

```
EXIT=0
```

### kube-linter

指摘数は変更前後で不変。

```
master: found 17 lint errors   branch: found 17 lint errors
```

## 未対応事項 (本 PR のスコープ外)

同じ調査で判明したが、緊急度が異なるため分離した。

1. **smart shutdown 問題** — kubeclarity の PostgreSQL も #9876 と同じく `not properly shut down` からのクラッシュリカバリになっている (再起動 7 回)。ただし本 PR の chart は sub-chart 構造で `primary.lifecycleHooks` が使えず、`patches` で当てる必要がある。
   ```
   2026-07-10 03:29:25.935 GMT [84] LOG:  database system was not properly shut down; automatic recovery in progress
   ```
2. **PostgreSQL 14.6.0 は EOL 済み** かつ `hostPath: /mnt/local/kubeclarity/postgresql` 運用のため、Pod が別ノードに移るとデータも失われる。kubeclarity 自体の要否を含めた見直しが必要。
3. **Bitnami 未対応の残り** — epgstation の mariadb / nebula の redis / influxdb。