### PR TITLE
fix(epgstation,influxdb): Bitnami イメージを bitnamilegacy に固定して pull 不可を解消する

### DIFF
--- a/k8s/apps/epgstation/kustomization.yaml
+++ b/k8s/apps/epgstation/kustomization.yaml
@@ -2,6 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: epgstation
 
+images:
+  # Bitnami は 2025-08 にバージョン固定タグを有償枠へ移し (無償は latest のみ)、
+  # 逃がし先だった public.ecr.aws のミラーも 2026-06 に削除した。
+  # 無償でバージョンを固定できるのは凍結済みの bitnamilegacy だけなので、そこに固定する。
+  # タグは稼働中の 12.0.2-MariaDB に合わせており、バージョンは動かしていない。
+  - name: docker.io/bitnami/mariadb
+    newName: docker.io/bitnamilegacy/mariadb
+    newTag: 12.0.2-debian-12-r0
+
 helmCharts:
   - name: mariadb
     releaseName: mariadb
@@ -12,11 +21,10 @@ helmCharts:
         database: epgstation
         existingSecret: mariadb-secret
         username: epgstation
-      global:
-        imageRegistry: public.ecr.aws
-        security:
-          # imageRegistry を変更するために必要
-          allowInsecureImages: true
+      image:
+        # チャートの既定は registry-1.docker.io だが、それだと上の images による
+        # 差し替えが名前一致せず無言で素通りするので docker.io に戻す
+        registry: docker.io
       primary:
         extraEnvVars:
           - name: TZ

--- a/k8s/apps/influxdb/kustomization.yaml
+++ b/k8s/apps/influxdb/kustomization.yaml
@@ -2,6 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: influxdb
 
+images:
+  # Bitnami は 2025-08 にバージョン固定タグを有償枠へ移し (無償は latest のみ)、
+  # 逃がし先だった public.ecr.aws のミラーも 2026-06 に削除した。
+  # 無償でバージョンを固定できるのは凍結済みの bitnamilegacy だけなので、そこに固定する。
+  # タグはチャート既定と同一で、バージョンは動かしていない。
+  - name: docker.io/bitnami/influxdb
+    newName: docker.io/bitnamilegacy/influxdb
+    newTag: 2.7.11-debian-12-r20
+
 helmCharts:
   - name: influxdb
     releaseName: influxdb
@@ -11,11 +20,6 @@ helmCharts:
     valuesInline:
       auth:
         existingSecret: admin-secret
-      global:
-        imageRegistry: public.ecr.aws
-        security:
-          # imageRegistry を変更するために必要
-          allowInsecureImages: true
       influxdb:
         resourcesPreset: medium
         service:


### PR DESCRIPTION
## 背景

#9877 に続く Bitnami レジストリ消滅への対応。epgstation の mariadb と influxdb は `global.imageRegistry` で `public.ecr.aws` のミラーへ逃がしていたが、**そのミラーも 2026-06 に削除された**ため既に pull できない。

```console
$ docker manifest inspect public.ecr.aws/bitnami/mariadb:latest
❌ pull 不可

$ docker manifest inspect public.ecr.aws/bitnami/influxdb:2.7.11-debian-12-r20
❌ pull 不可
```

現在はノードのイメージキャッシュで動いているだけで、再スケジュールされた時点で ImagePullBackOff になる。

## 変更内容

他アプリ (#9869, #9877) と同じく `images:` で `bitnamilegacy` にバージョン固定し、`global.imageRegistry` / `allowInsecureImages` を落とす。

mariadb チャートの既定レジストリは `registry-1.docker.io` で、そのままだと `images:` の名前一致が外れて**無言で素通りする**ため、`image.registry: docker.io` を明示する (n8n と同じ対処)。influxdb は既定が `docker.io` なので不要。

### タグの決定根拠

チャート既定は `latest` だが、`bitnamilegacy` の `latest` は 2025-07 で凍結された古いイメージを指すため、**稼働中の実バージョンに合わせて固定**する。

| | 変更前 | 変更後 | 根拠 |
| --- | --- | --- | --- |
| mariadb | `latest` | `12.0.2-debian-12-r0` | 稼働中の Pod ログが `Version: '12.0.2-MariaDB-log'` |
| influxdb | `2.7.11-debian-12-r20` | 同一タグ | `bitnamilegacy` に同じタグが存在 |

いずれもバージョンは動かしていない。

## 検証

### イメージの取得可否

```console
$ docker manifest inspect docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0
✅ 取得可能
$ docker manifest inspect docker.io/bitnamilegacy/influxdb:2.7.11-debian-12-r20
✅ 取得可能
```

### mariadb が稼働中と同一バージョンであることの確認

```console
$ docker run --rm --entrypoint mariadbd docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0 --version
mariadbd  Ver 12.0.2-MariaDB for Linux on x86_64 (Source distribution)
```

稼働中の `12.0.2-MariaDB-log` と一致 (`-log` はバイナリログ有効時の接尾辞)。

### API サーバーとの実差分 (server-side dry-run)

image のみ。

```console
$ kubectl -n epgstation diff -f sts.yaml
-        image: public.ecr.aws/bitnami/mariadb:latest
+        image: docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0
(2 箇所: mariadb コンテナと preserve-logs-symlinks initContainer)

$ kubectl -n influxdb diff -f deploy.yaml
-        image: public.ecr.aws/bitnami/influxdb:2.7.11-debian-12-r20
+        image: docker.io/bitnamilegacy/influxdb:2.7.11-debian-12-r20
```

生成マニフェスト差分には influxdb 側に `initContainers: null` → `[]` も出るが、API 上等価のため上記 dry-run では差分に現れない。

### `go run ./cmd/build-manifests` / ESLint

```
build-manifests EXIT=0
ESLint EXIT=0
```

### kube-linter

influxdb は不変。epgstation は `latest` を外したことで `latest-tag` の指摘 2 件が**減った**。

```
epgstation   master: found 20 lint errors   branch: found 18 lint errors
influxdb     master: found  2 lint errors   branch: found  2 lint errors

$ diff <(master の check 別集計) <(branch の check 別集計)
<       2 (check: latest-tag
```

## 未対応事項

- **nebula の redis** は別 PR にする。稼働中が 8.2.2 なのに対し `bitnamilegacy` の最大が 8.2.1 で、パッチレベルのダウングレードを伴うため。RDB/AOF の互換性を検証したうえで出す。
- 本 PR は再スケジュール時の起動可否を直すもので、**実際に Pod を入れ替えての動作確認は未実施**。マージ後に mariadb / influxdb が正常起動することの確認が必要。