### PR TITLE
fix(nebula): redis を bitnamilegacy に固定して pull 不可を解消する

### DIFF
--- a/k8s/apps/nebula/kustomization.yaml
+++ b/k8s/apps/nebula/kustomization.yaml
@@ -11,6 +11,12 @@ images:
     # チャート 18.x の既定タグは latest で、bitnamilegacy の latest は 2025-07 時点の
     # 古いイメージになるため、これまでレンダリングされていたタグを明示する
     newTag: 12-debian-12-r51@sha256:77e65e9d633ec1463f8bea185763aa7ef91e5ddbe0b60beb1b0b5d4da58882b6
+  - name: docker.io/bitnami/redis
+    newName: docker.io/bitnamilegacy/redis
+    # チャート既定タグは latest で、bitnamilegacy の latest は 2025-07 時点の古いイメージに
+    # なるため明示する。bitnamilegacy は凍結済みで稼働中の 8.2.2 を収録しておらず 8.2.1 が最新だが、
+    # 8.2.2 が書いた Multi-Part AOF を 8.2.1 が読めることは検証済み。
+    newTag: 8.2.1-debian-12-r0
 
 helmCharts:
   - name: postgresql
@@ -61,11 +67,10 @@ helmCharts:
       architecture: standalone
       auth:
         existingSecret: redis-secret
-      global:
-        imageRegistry: public.ecr.aws
-        security:
-          # imageRegistry を変更するために必要
-          allowInsecureImages: true
+      image:
+        # チャートの既定は registry-1.docker.io だが、それだと上の images による
+        # 差し替えが名前一致せず無言で素通りするので docker.io に戻す
+        registry: docker.io
       master:
         extraEnvVars:
           - name: TZ


### PR DESCRIPTION
## 背景

#9881 と同じく Bitnami レジストリ消滅への対応。nebula の redis も `global.imageRegistry` で `public.ecr.aws` へ逃がしていたが、**そのミラーも削除済み**。

```console
$ docker manifest inspect public.ecr.aws/bitnami/redis:latest
❌ pull 不可
```

現在はノードのイメージキャッシュで動いているだけで、再スケジュールされた時点で ImagePullBackOff になる。

本 PR を #9881 から分けたのは、**パッチレベルのダウングレードを伴う**ため。稼働中は 8.2.2 だが、`bitnamilegacy` は 2025-07 で凍結されており 8.2.1 が最新。

```console
$ curl -s "https://hub.docker.com/v2/repositories/bitnamilegacy/redis/tags?name=8.2" | jq -r '.results[].name'
8.2.1-debian-12-r0        # ← 8.2.2 は存在しない
```

## 互換性の検証

nebula の redis は **Multi-Part AOF** (base が RDB 形式) で永続化している。

```console
$ kubectl -n nebula logs redis-master-0 | grep -iE 'AOF|RDB'
* Reading RDB base file on AOF loading...
* Loading RDB produced by version 8.2.2
* DB loaded from base file appendonly.aof.16.base.rdb: 0.003 seconds
* DB loaded from incr file appendonly.aof.16.incr.aof: 0.013 seconds
```

そこで **8.2.2 が書いたデータを 8.2.1 が読めるか**をローカルで実証した。

### 手順

1. `redis:8.2.2` を `--appendonly yes` で起動し、string / list / hash を書き込んで `bgrewriteaof`
2. 生成された `appendonlydir` (本番と同じ `appendonly.aof.N.base.rdb` + `.incr.aof` + `.manifest` 構成) を
3. `bitnamilegacy/redis:8.2.1-debian-12-r0` に同じボリュームを渡して起動

### 結果

```console
$ docker run --rm --entrypoint redis-server docker.io/bitnamilegacy/redis:8.2.1-debian-12-r0 --version
Redis server v=8.2.1 sha=00000000:1 malloc=jemalloc-5.3.0 bits=64

# 8.2.1 側の起動ログ
1:M 08 Aug 2026 07:02:32.378 * Loading RDB produced by version 8.2.2
1:M 08 Aug 2026 07:02:32.378 * Done loading RDB, keys loaded: 3, keys expired: 0.
1:M 08 Aug 2026 07:02:32.378 * DB loaded from base file appendonly.aof.2.base.rdb: 0.000 seconds
1:M 08 Aug 2026 07:02:32.378 * DB loaded from append only file: 0.000 seconds
1:M 08 Aug 2026 07:02:32.383 * Ready to accept connections tcp
```

データも全て復元された。

| 型 | 書き込み (8.2.2) | 読み出し (8.2.1) |
| --- | --- | --- |
| dbsize | 3 | 3 |
| string | `value-from-8.2.2` | `value-from-8.2.2` |
| list | `a b c` | `a b c` |
| hash | `f1 v1 f2 v2` | `f1 v1 f2 v2` |

8.2.1 の `redis-check-rdb` による検査も通った。

```console
$ redis-check-rdb /data/appendonlydir/appendonly.aof.2.base.rdb
[offset 192] Checksum OK
[offset 192] \o/ RDB looks OK! \o/
```

## 変更内容

`images:` で `bitnamilegacy` に固定し、`global.imageRegistry` / `allowInsecureImages` を落とす。チャート既定レジストリが `registry-1.docker.io` で `images:` の名前一致が外れて無言で素通りするため、`image.registry: docker.io` を明示する。

## 検証

### 生成マニフェスト差分

`kustomize build` の出力には TLS 証明書 (`ca.crt` / `tls.crt` / `tls.key`) の差分も出るが、これは postgresql チャートが**ビルドのたびに自己署名証明書を生成する**ためで、本 PR とは無関係。同一コードで 2 回ビルドしても同じ差分が出ることを確認した。

```console
$ kustomize build ... > n1.yaml; kustomize build ... > n2.yaml; diff n1.yaml n2.yaml
差分行数: 8   (ca.crt / tls.crt / tls.key のみ)
```

証明書を除外した実差分は image の 1 行だけ。

```diff
-        image: public.ecr.aws/bitnami/redis:latest
+        image: docker.io/bitnamilegacy/redis:8.2.1-debian-12-r0
```

### API サーバーとの実差分 (server-side dry-run)

```console
$ kubectl -n nebula diff -f sts.yaml
-        image: public.ecr.aws/bitnami/redis:latest
+        image: docker.io/bitnamilegacy/redis:8.2.1-debian-12-r0
```

### `go run ./cmd/build-manifests` / ESLint

```
build-manifests EXIT=0
ESLint EXIT=0
```

### kube-linter

`latest` を外したことで `latest-tag` の指摘が 1 件減った。

```
master: found 55 lint errors   branch: found 54 lint errors
```

## 未検証事項

- **実際に Pod を入れ替えての動作確認は未実施。** ローカルでの AOF 互換性検証とサーバー dry-run に留めている。マージ後、redis-master-0 の起動ログに `Loading RDB produced by version 8.2.2` → `Ready to accept connections` が出れば期待どおり。
- ダウングレード後に 8.2.1 が書いたデータを将来 8.2.2 以降で読むことになるが、こちらは上位互換なので問題ない。

## 別途報告

本 PR のスコープ外だが、**nebula の `kustomize build` はビルドのたびに TLS 証明書が変わる**ため、ArgoCD が恒常的に差分を検出している可能性がある (postgresql チャートの `tls.autoGenerated` 相当の挙動)。必要なら別 issue を立てる。