### PR TITLE
fix(kubeclarity): preStop で fast shutdown してクラッシュリカバリを避ける

### DIFF
--- a/k8s/apps/kubeclarity/kustomization.yaml
+++ b/k8s/apps/kubeclarity/kustomization.yaml
@@ -39,3 +39,19 @@ patches:
           hostPath:
             path: /mnt/local/kubeclarity/postgresql
             type: DirectoryOrCreate
+      # Bitnami の PostgreSQL イメージは STOPSIGNAL を設定しておらず、PID 1 の postgres は
+      # SIGTERM を smart shutdown (既存クライアントが自ら切断するまで待つ) と解釈する。
+      # kubeclarity がコネクションを保持し続けるので待機が終わらず、
+      # terminationGracePeriodSeconds 満了で SIGKILL され、毎回クラッシュリカバリになる。
+      # 他アプリ (#9876) はチャートの primary.lifecycleHooks で対処したが、
+      # ここは sub-chart で values を渡せないため patch で当てる。
+      - op: add
+        path: /spec/template/spec/containers/0/lifecycle
+        value:
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                # terminationGracePeriodSeconds (30 秒) を超えないよう -t で頭打ちにする
+                - pg_ctl stop -D "$PGDATA" -m fast -w -t 25


### PR DESCRIPTION
## 背景

#9876 で対処した smart shutdown 問題の積み残し。kubeclarity の PostgreSQL は sub-chart のため `primary.lifecycleHooks` を渡せず、意図的にスコープ外としていた。

今も再起動のたびにクラッシュリカバリになっている。

```console
$ kubectl -n kubeclarity logs kubeclarity-kubeclarity-postgresql-0 | grep -E 'starting|shut down|ready'
LOG:  starting PostgreSQL 14.10 on x86_64-pc-linux-gnu
LOG:  database system was not properly shut down; automatic recovery in progress
LOG:  database system is ready to accept connections
```

原因は #9876 と同じ。Bitnami の PostgreSQL イメージは `STOPSIGNAL` を設定しておらず PID 1 = postgres が SIGTERM を受け取るが、PostgreSQL にとって SIGTERM は **smart shutdown** (既存クライアントが自ら切断するまで待つ) を意味する。kubeclarity がコネクションを保持し続けるので待機は終わらず、`terminationGracePeriodSeconds` (30 秒) 満了で SIGKILL される。

## 変更内容

チャートの values を渡せないため、既存の `patches` に JSON Patch で追記する。

```yaml
- op: add
  path: /spec/template/spec/containers/0/lifecycle
  value:
    preStop:
      exec:
        command:
          - /bin/sh
          - -c
          - pg_ctl stop -D "$PGDATA" -m fast -w -t 25
```

適用先の構成は #9876 の対象と同一。

```console
$ kubectl -n kubeclarity get sts kubeclarity-kubeclarity-postgresql \
    -o jsonpath='container={.spec.template.spec.containers[0].name}{"\n"}grace={.spec.template.spec.terminationGracePeriodSeconds}'
container=postgresql
grace=30

$ ... env PGDATA
PGDATA=/bitnami/postgresql/data
```

## 検証

### PostgreSQL 14 でも preStop コマンドが機能することの確認

#9876 は 17.6.0 で検証したので、こちらは実際に使われている 14.10.0 で改めて確認した。本番同等の制約 (非 root uid 1001 / read-only rootfs / 接続保持あり) で実行。

```console
$ docker exec pg14test sh -c 'pg_ctl stop -D "$PGDATA" -m fast -w -t 25'
waiting for server to shut down.... done
所要秒数: 0

$ docker logs pg14test | grep -iE 'shutdown|shut down'
LOG:  received fast shutdown request
LOG:  database system is shut down
```

再起動時もクラッシュリカバリが消えた。

```console
$ docker start pg14test && docker logs pg14test | grep -E 'not properly|was shut down at'
LOG:  database system was shut down at 2026-08-08 07:20:46 GMT
```

| | 修正前 (SIGTERM) | 修正後 (preStop) |
| --- | --- | --- |
| 停止所要時間 | 30 秒 (grace period 満了 → SIGKILL) | 1 秒未満 |
| 停止時ログ | `received smart shutdown request` で停止 | `database system is shut down` まで到達 |
| 次回起動時 | `not properly shut down; automatic recovery in progress` | `database system was shut down at ...` |

### patch が正しいコンテナに当たることの確認

```console
container: postgresql
lifecycle: {"preStop": {"exec": {"command": ["/bin/sh", "-c", "pg_ctl stop -D \"$PGDATA\" -m fast -w -t 25"]}}}
PGDATA: ['/bitnami/postgresql/data']
```

### API サーバーとの実差分 (server-side dry-run)

preStop の追加のみ。破棄もされていない。

```console
$ kubectl -n kubeclarity diff -f sts.yaml
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - pg_ctl stop -D "$PGDATA" -m fast -w -t 25
```

### `go run ./cmd/build-manifests` / ESLint / kube-linter

```
build-manifests EXIT=0
ESLint EXIT=0
kube-linter  master: found 17 lint errors   branch: found 17 lint errors
```

## 未検証事項

- **実クラスタでの preStop 発火は未検証。** StatefulSet を更新しても削除される Pod は旧 spec で動くため、初回の発火は次に PostgreSQL が停止するときになる。そのとき起動ログが `database system was shut down at ...` になれば実証完了。
- 同じ理由で #9876 の preStop もまだ一度も発火していない。