### PR TITLE
chore(mackerel-operator): chart を 0.1.4 に更新

### DIFF
--- a/k8s/system/mackerel-operator/kustomization.yaml
+++ b/k8s/system/mackerel-operator/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: mackerel-operator
     releaseName: mackerel-operator
     namespace: mackerel-operator
-    version: 0.1.2
+    version: 0.1.4
     repo: https://slashnephy.github.io/mackerel-operator
     includeCRDs: true
 


### PR DESCRIPTION
## 変更内容

`mackerel-operator` の Helm chart を 0.1.2 から 0.1.4 へ更新する。イメージは `ghcr.io/slashnephy/mackerel-operator:0.1.4` になる。

Reconcile が Kubernetes API へ書き込む方法を 2 点変えたリリース。

**1. status / finalizer の更新を `Update` から `Patch` へ**

Reconcile はリソースを一度読んだあと Mackerel API と通信してから status を書き戻す。この往復の間に spec が編集されると `resourceVersion` が進むため、`Status().Update` が楽観的並行制御に弾かれていた。

このクラスタでも実際に発生している。

```console
$ kubectl logs -n mackerel-operator deploy/mackerel-operator --since=24h | grep -c 'object has been modified'
6
```

`Patch` は `resourceVersion` の前提条件を持たないため、この衝突が構造的に起きなくなる。

**2. 同期済みのときに status を書かない**

`lastSyncedAt` を reconcile のたびに打ち直していたため、監視対象が何も変わっていなくても status に差分が生まれ、`RequeueAfter: 1m` と相まって ExternalMonitor 1 件につき毎分 1 回の書き込みが発生していた。現在 11 件あるので毎分 11 回。

`lastSyncedAt` は実際に Mackerel へ書き込んだときのみ進めるようにし、status に差分がなければリクエスト自体を発行しないようにした。

## 変更前の状態

2 分半の間に全 11 件の `resourceVersion` が進み、`lastSyncedAt` も毎分更新されている（spec は未変更、`generation` は 1 のまま）。

```
=== 17:53:30 ===                                          === 17:56:00 (+150s) ===
archi-steam-farm  346700475  2026-08-08T08:53:02Z         archi-steam-farm  346700969  2026-08-08T08:55:03Z
argo-cd           346700363  2026-08-08T08:52:32Z         argo-cd           346701128  2026-08-08T08:55:32Z
authentik         346700528  2026-08-08T08:53:15Z         authentik         346701071  2026-08-08T08:55:16Z
file-browser      346700479  2026-08-08T08:53:03Z         file-browser      346700972  2026-08-08T08:55:03Z
grafana           346700513  2026-08-08T08:53:12Z         grafana           346701049  2026-08-08T08:55:12Z
influxdb          346700511  2026-08-08T08:53:12Z         influxdb          346701045  2026-08-08T08:55:12Z
konomitv          346700442  2026-08-08T08:52:53Z         konomitv          346701205  2026-08-08T08:55:54Z
k8s-dashboard     346700510  2026-08-08T08:53:12Z         k8s-dashboard     346701044  2026-08-08T08:55:12Z
n8n               346700512  2026-08-08T08:53:12Z         n8n               346701046  2026-08-08T08:55:12Z
navidrome         346700447  2026-08-08T08:52:54Z         navidrome         346701207  2026-08-08T08:55:54Z
traefik           346700537  2026-08-08T08:53:18Z         traefik           346701083  2026-08-08T08:55:19Z
```

マージ後に同じ計測を行い、結果をコメントする。

## 検証

```console
$ kubectl kustomize --enable-helm k8s/system/mackerel-operator | grep image:
        image: ghcr.io/slashnephy/mackerel-operator:0.1.4

$ pnpm eslint
（指摘なし）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)