### PR TITLE
chore(mackerel-operator): chart を 0.2.0 に更新

### DIFF
--- a/k8s/system/mackerel-operator/kustomization.yaml
+++ b/k8s/system/mackerel-operator/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: mackerel-operator
     releaseName: mackerel-operator
     namespace: mackerel-operator
-    version: 0.1.4
+    version: 0.2.0
     repo: https://slashnephy.github.io/mackerel-operator
     includeCRDs: true
 


### PR DESCRIPTION
mackerel-operator の chart を `0.1.4` から `0.2.0` に更新する。

`ExternalMonitor` で `isMute`, `followRedirect`, `skipCertificateVerification`, `maxCheckAttempts`, `requestBody`, `headers` の 6 つが書けるようになる。従来 CRD に `max_check_attempts` 相当が無かったため Terraform に残していた epgstation と mahiron も、これで移行の前提が揃う（本 PR では移行しない）。

## ⚠️ マージ前に判断が要る: Cache-Control ヘッダーが外れる

**現在 operator 管理下にある外形監視 11 件はすべて `Cache-Control: no-cache` ヘッダーを持っているが、CR 側で `headers` を書いているものは 1 件も無い。**

```
archi-steam-farm/https      kubernetes-dashboard/https
argo-cd/https               n8n/https
authentik/https             navidrome/https
file-browser/https          traefik/https
grafana/https               konomitv/https
influxdb/https
```

0.2.0 では `headers` が operator の所有になる。CR に書かれていない状態は「ヘッダー無し」と解釈されるため、**このままマージすると 11 件すべてからこのヘッダーが外れる。** Argo CD は `automated` + `selfHeal` なので、マージした時点で反映される。

外形監視から `Cache-Control: no-cache` が外れると、CDN やリバースプロキシがキャッシュ済みの 200 を返した場合に、実際には落ちているサービスが正常と判定されうる。

このヘッダーの出所は本リポジトリではない。移行元の Terraform 定義 (`mackerel_monitor_external_*.tf`) に header の記述は無く、Mackerel 側で設定されたものと見られる。0.2.0 が想定している「operator の外で設定した値は CR の値に置き換わる」ケースそのものに該当する。

### 選択肢

1. **維持する** — 11 件の CR に以下を追加してから、この PR と一緒にマージする。現状の監視挙動が変わらない。

   ```yaml
   spec:
     headers:
       - name: Cache-Control
         value: no-cache
   ```

2. **意図的に外す** — このヘッダーが不要であればこのままマージする。11 件から一斉に外れる。

3. **先に Mackerel 側を確認する** — 誰がなぜ設定したか判明してから決める。

1 を選ぶ場合は言ってもらえればこの PR に追加する。CR 側の変更と chart 更新は同じ sync に入れたほうがよい（別々にすると、chart だけ先に入った時点で一度ヘッダーが外れる）。

## その他の挙動変更

- **一度だけ全件 Update が走る。** `maxCheckAttempts` の既定値 `1` が desired のハッシュを変えるため、既存の `ExternalMonitor` 11 件それぞれに Update が 1 回発生する。冪等な書き込みなので実害は無い。
- **ミュートの上書き。** Mackerel の Web UI でミュートした監視は、CR が `isMute: true` を書いていなければミュートが解除される。今回 11 件を確認したところ **ミュート中のものは無かった**ため、この PR では影響しない。
- **採用条件が厳しくなる。** マーカーを持たない同名の監視を operator が採用する条件に 6 フィールドが加わる。値が CR と一致しない場合は採用されず `OwnershipLost` になる。

## 検証

```
$ kubectl kustomize --enable-helm k8s/system/mackerel-operator
（レンダリング成功）

CRD に含まれる新フィールド: isMute, followRedirect, skipCertificateVerification,
                            maxCheckAttempts, requestBody, headers（6 件）
image: ghcr.io/slashnephy/mackerel-operator:0.2.0
```

upstream: SlashNephy/mackerel-operator#320, SlashNephy/mackerel-operator#321
