### PR TITLE
fix(nebula): worker と ml に resources を設定し backup-contents に打ち切りを追加

### DIFF
--- a/k8s/apps/nebula/resources/cronjob-backup-contents.yaml
+++ b/k8s/apps/nebula/resources/cronjob-backup-contents.yaml
@@ -9,6 +9,11 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
+      # 暴走時の打ち切り。通常でも 86 分かかる（2026-08-14 実測 5155 秒）ため、
+      # 正常な同期を殺さないよう通常値の約 2 倍に置く。
+      # concurrencyPolicy: Forbid があるので多重起動はしないが、上限がないと
+      # 1 本が走り続けてノードの I/O を占有し続ける
+      activeDeadlineSeconds: 10800
       template:
         spec:
           containers:

--- a/k8s/apps/nebula/resources/cronjob-backup-contents.yaml
+++ b/k8s/apps/nebula/resources/cronjob-backup-contents.yaml
@@ -8,12 +8,12 @@ spec:
   timeZone: Asia/Tokyo
   jobTemplate:
     spec:
-      backoffLimit: 0
       # 暴走時の打ち切り。通常でも 86 分かかる（2026-08-14 実測 5155 秒）ため、
       # 正常な同期を殺さないよう通常値の約 2 倍に置く。
       # concurrencyPolicy: Forbid があるので多重起動はしないが、上限がないと
       # 1 本が走り続けてノードの I/O を占有し続ける
       activeDeadlineSeconds: 10800
+      backoffLimit: 0
       template:
         spec:
           containers:

--- a/k8s/apps/nebula/resources/deployment-ml.yaml
+++ b/k8s/apps/nebula/resources/deployment-ml.yaml
@@ -39,13 +39,13 @@ spec:
           # 立ってしまうため、意図的に Burstable に留める。
           # memory limits は MAX_MEMORY_MB=8192 に対する余裕を見て 10Gi
           resources:
+            limits:
+              cpu: "3"
+              gpu.intel.com/i915: "1"
+              memory: 10Gi
             requests:
               cpu: 500m
               memory: 2Gi
-            limits:
-              cpu: "3"
-              memory: 10Gi
-              gpu.intel.com/i915: "1"
           livenessProbe:
             failureThreshold: 5
             httpGet:

--- a/k8s/apps/nebula/resources/deployment-ml.yaml
+++ b/k8s/apps/nebula/resources/deployment-ml.yaml
@@ -34,8 +34,17 @@ spec:
               mountPath: /cache
             - name: tmp
               mountPath: /tmp
+          # requests は低く、limits で上限を切る。requests を書かずに limits だけ置くと
+          # requests が limits と同値になり Guaranteed に昇格して etcd との競合で優位に
+          # 立ってしまうため、意図的に Burstable に留める。
+          # memory limits は MAX_MEMORY_MB=8192 に対する余裕を見て 10Gi
           resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
             limits:
+              cpu: "3"
+              memory: 10Gi
               gpu.intel.com/i915: "1"
           livenessProbe:
             failureThreshold: 5

--- a/k8s/apps/nebula/resources/deployment-worker.yaml
+++ b/k8s/apps/nebula/resources/deployment-worker.yaml
@@ -30,6 +30,16 @@ spec:
               mountPath: /app/avatars
             - name: tmp
               mountPath: /tmp
+          # requests は低く、limits で上限を切る。requests を書かずに limits だけ置くと
+          # requests が limits と同値になり Guaranteed に昇格して etcd との競合で優位に
+          # 立ってしまうため、意図的に Burstable に留める
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/k8s/apps/nebula/resources/deployment-worker.yaml
+++ b/k8s/apps/nebula/resources/deployment-worker.yaml
@@ -34,12 +34,12 @@ spec:
           # requests が limits と同値になり Guaranteed に昇格して etcd との競合で優位に
           # 立ってしまうため、意図的に Burstable に留める
           resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
             limits:
               cpu: "1"
               memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## 背景

lily で複数の namespace にまたがる CrashLoopBackOff が発生していた。調査の結果、原因は **ノードのリソース飽和 → etcd の停止 → leader election の一斉失敗** だった。

```
ノード lily の飽和 (load 35 / 8 コア, idle 1%)
  → etcd が CPU/IO を奪われる
  → scheduled compaction が 31〜52 秒かかり、その間 etcd が実質停止
  → apiserver が "etcdserver: request timed out" を返す
  → leader election 中のコンポーネントが lease を更新できず、設計どおり自ら exit
```

3 つのコンポーネントが同一秒に、同一理由で死んでいる。

| コンポーネント | 死亡時刻 | 終了理由 |
| --- | --- | --- |
| kube-scheduler | 10:38:34Z | `Leaderelection lost` |
| cilium-operator | 10:38:34Z | `Leader election lost, shutting down.` |
| openclaw-operator | 10:38:29Z | `etcdserver: request timed out` |

etcd 側のログ:

```
10:34:06Z  finished scheduled compaction  took=51.993621999s
10:38:45Z  finished scheduled compaction  took=30.934802972s   ← 開始 10:38:14
```

停止窓 10:38:14〜10:38:45 が上表のクラッシュ時刻を完全に包含する。なお `cilium-agent`（データプレーン本体）は 6 日 18 時間ノーリスタートで健全であり、cilium 自体に問題はない。

負荷源の実測（`/proc/<pid>/io` の 5 秒デルタ）:

```
137.2 MB/s  nebula/worker-...-nkbv6      qos=BestEffort
 53.2 MB/s  nebula/backup-database-*     qos=BestEffort
 38.8 MB/s  n8n/n8n-...                  qos=BestEffort
 34.0 MB/s  nebula/worker-...-nbd49      qos=BestEffort
CPU 241%    nebula/ml-...                qos=BestEffort (RSS 3.1GB)
```

Running 106 Pod 中 78 が BestEffort で、Guaranteed はゼロだった。

## 変更内容

### `worker` / `ml` に resources を設定

requests は低いまま limits で上限を切る。

`limits` だけを書くと requests が自動的に limits と同値になり **Guaranteed に昇格**してしまい、etcd との競合でかえって優位に立つ。それを避けるため requests を明示して **Burstable** に留めている。

| Deployment | requests | limits |
| --- | --- | --- |
| `worker` | cpu 100m / memory 256Mi | cpu 1 / memory 2Gi |
| `ml` | cpu 500m / memory 2Gi | cpu 3 / memory 10Gi / i915 1 |

`ml` の memory limit は `MAX_MEMORY_MB=8192` に対する余裕を見て 10Gi とした。

### `backup-contents` に `activeDeadlineSeconds` を追加

`concurrencyPolicy: Forbid` は既に設定済みだったため、暴走時の打ち切りのみを追加した。

このジョブは**通常でも 86 分**かかる（2026-08-14 実測 5155 秒）ため、正常な同期を殺さないよう通常値の約 2 倍の 3 時間（10800 秒）に置いた。

## トレードオフ

**`worker` の CPU limit 1 コアは、`extract_audio_metadata` のタイムアウト率を上げる方向に働きうる。**

このジョブの失敗は全て worker → ffmpeg への 60 秒タイムアウトで起きており、worker は同時に 4〜8 ジョブを回している。CPU を絞れば各ジョブの処理が遅くなり、タイムアウトが増えてリトライが積み増される可能性がある。

この limit はノードを守る防波堤であって、根本治療ではない。本命は worker 側のタイムアウトとリトライ設計の見直しで、そちらは nebula 側に別途報告している。マージ後に `extract_audio_metadata` の失敗が増えた場合、この PR が原因ではなくアプリ側の問題が顕在化したものとして切り分けてほしい。

## 証跡

### BEFORE（実クラスタの現状）

```
$ kubectl -n nebula get deploy worker ml -o json | ...
  Deployment/worker resources={} (=BestEffort)
  Deployment/ml resources={'limits': {'gpu.intel.com/i915': '1'}}

$ kubectl -n nebula get cronjob backup-contents -o jsonpath='{.spec.jobTemplate.spec.activeDeadlineSeconds}'
  (空)
```

### AFTER（`kubectl apply --server-side --dry-run=server` で API server が受理した結果）

```
OK  Deployment/ml      requests={'cpu': '500m', 'memory': '2Gi'} limits={'cpu': '3', 'gpu.intel.com/i915': '1', 'memory': '10Gi'} -> QoS=Burstable
OK  Deployment/worker  requests={'cpu': '100m', 'memory': '256Mi'} limits={'cpu': '1', 'memory': '2Gi'} -> QoS=Burstable
OK  CronJob/backup-contents activeDeadlineSeconds=10800 concurrencyPolicy=Forbid
```

狙いどおり Guaranteed へ昇格せず Burstable に留まっていることを確認した。

### ビルドと lint

```
$ go run ./cmd/build-manifests
... ✅ kustomize build succeeded (全 root)
exit=0

$ kube-linter lint --config .kube-linter.yaml ./k8s
lint エラー総数  before=633  after=633
```

lint 総数が変わらないのは、`unset-cpu-requirements` と `unset-memory-requirements` が `.kube-linter.yaml` で除外されているため。本 PR による新規指摘はない。

## 未検証事項

- **ランタイム検証は未実施。** マージして Argo CD が sync した後に、新しい Pod の `qosClass` が実際に `Burstable` になり、ノードの load average が下がるかを確認する必要がある
- resources の値は実測（worker RSS 135MB / ml RSS 3.1GB・CPU 2.4 コア）に基づく判断であり、高負荷時に十分かは運用しながらの調整が要る
- `backup-database` にも同様の `activeDeadlineSeconds` を入れる余地があるが、本 PR のスコープ外とした（通常 5.7 分で完了しており緊急性が低い）

## 別途対応が必要な事項（本 PR のスコープ外）

- etcd の requests が kubeadm 既定の 100m のままで、飽和時に保護にならない（`/etc/kubernetes/manifests/etcd.yaml`、ノードローカル）
- kubelet の `systemReserved` / `kubeReserved` が未設定の可能性（`/var/lib/kubelet/config.yaml`、ノードローカル）
- `extract_audio_metadata` のリトライストーム（nebula アプリ側）
