### PR TITLE
chore(argo-cd): 引き継ぎ作業のあいだリソースを保全する

### DIFF
--- a/k8s/system/argo-cd/resources/application-set-lily.yaml
+++ b/k8s/system/argo-cd/resources/application-set-lily.yaml
@@ -280,3 +280,9 @@ spec:
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/syncPolicy
+  # ApplicationSet は既定で生成した Application に resources-finalizer を付ける。
+  # element を外すと Application の削除が実リソースへ波及するため、
+  # Application を別の管理下へ引き継ぐ作業のあいだだけ、リソースを保全する側へ倒す。
+  # 引き継ぎが済んだらこのブロックごと戻す。
+  syncPolicy:
+    preserveResourcesOnDeletion: true


### PR DESCRIPTION
`lily-application-set` に `syncPolicy.preserveResourcesOnDeletion: true` を一時的に入れる。

## なぜ

ApplicationSet は既定で、生成した Application に `resources-finalizer.argocd.argoproj.io` を付ける。この状態で element を一覧から外すと、Application の削除が**管理下の実リソースへ波及する**。PVC を持つアプリでは data volume ごと消える。

Application を ApplicationSet 管理から別の管理下へ引き継ぐ作業では、リソースを残したまま Application だけを消す必要がある。

## 実測

element を外す前に finalizer を手で外せるかを試したが、**ApplicationSet コントローラが 10 秒以内に付け直す**（10 秒間隔で 9 回観測、すべて付与済み）。手作業では回避できない。

```console
$ kubectl -n argo-cd patch application <name> --type=merge -p '{"metadata":{"finalizers":[]}}'
$ # 10 秒後
["resources-finalizer.argocd.argoproj.io"]
```

git に直接定義した standalone の Application には finalizer が付いていないことも確認済みで、付与元が ApplicationSet コントローラであることの裏付けになっている。

## 影響

この ApplicationSet が生成する全 54 アプリに効く。有効なあいだは、一覧から外したアプリの実リソースが削除されずに残る（`orphanedResources.warn: true` により Argo CD UI に警告として現れる）。

**引き継ぎが済んだら revert する。** 他アプリの最終状態は変わらない。

## 検証

- `kustomize build --enable-helm --load-restrictor LoadRestrictionsNone k8s/system/argo-cd` → exit 0
- `syncPolicy` が `{'preserveResourcesOnDeletion': True}` として解釈され、element 数 54 に変化が無いことを確認

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>