### PR TITLE
Revert "chore(argo-cd): 引き継ぎ作業のあいだリソースを保全する"

### DIFF
--- a/k8s/system/argo-cd/resources/application/lily.yaml
+++ b/k8s/system/argo-cd/resources/application/lily.yaml
@@ -276,9 +276,3 @@ spec:
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/syncPolicy
-  # ApplicationSet は既定で生成した Application に resources-finalizer を付ける。
-  # element を外すと Application の削除が実リソースへ波及するため、
-  # Application を別の管理下へ引き継ぐ作業のあいだだけ、リソースを保全する側へ倒す。
-  # 引き継ぎが済んだらこのブロックごと戻す。
-  syncPolicy:
-    preserveResourcesOnDeletion: true


### PR DESCRIPTION
#10017 で一時的に入れた `preserveResourcesOnDeletion: true` を戻す。

## 経緯

nebula の Application を ApplicationSet 管理から `lily-nebula-argo-cd` 配下へ引き継ぐため、リソースを残したまま Application だけを消す必要があった。引き継ぎは完了している。

## 戻して安全な理由

引き継ぎ後の `nebula` Application は **git に直接定義された Application** で、ApplicationSet の生成物ではない。

```console
$ kubectl -n argo-cd get application nebula -o jsonpath='{.metadata.finalizers}  owner={.metadata.ownerReferences[0].kind}'
  owner=
```

`lily-private-argo-cd` と同じく finalizer も ownerReference も持たないため、このフラグを戻しても影響を受けない。

戻すと ApplicationSet 生成分の 53 アプリに finalizer が復帰し、#10017 以前の状態に戻る。

## 前提

**#10019（移設済みマニフェストの削除）を先にマージすること。** 保護が効いているあいだに削除を済ませる順序にしている。