### PR TITLE
fix(traefik): プラグインの読み込み失敗時に lily の Traefik を起動させない

### DIFF
--- a/k8s/system/traefik/lily/values.yaml
+++ b/k8s/system/traefik/lily/values.yaml
@@ -60,6 +60,13 @@ env:
     value: Asia/Tokyo
 
 experimental:
+  # プラグインの取得は起動時に一度だけ行われ、失敗しても Traefik はそのまま起動する。
+  # ノード起動直後は CoreDNS が未 Ready なため plugins.traefik.io を解決できず、
+  # cloudflarewarp が無効のまま上がる。すると websecure の既定 middleware である
+  # trust-cloudflare-ips が「存在しない middleware」となり、全ルーターが読み込まれず
+  # 404 を返し続ける。/ping は 200 のままなので probe では検知できない。
+  # 起動を中止させることで kubelet の再起動に委ね、DNS 復旧後に自動回復させる。
+  abortOnPluginFailure: true
   plugins:
     cloudflarewarp:
       moduleName: github.com/BetterCorp/cloudflarewarp


### PR DESCRIPTION
## 事象

lily の Traefik が、ノード起動直後のような不安定な時間帯に起動すると、`websecure` を通る全ホストが 404 を返し続ける。

```
ERR error="invalid middleware \"traefik-trust-cloudflare-ips@kubernetescrd\" configuration: invalid middleware type or middleware does not exist" entryPointName=websecure routerName=...
```

Pod は `1/1 Running` であり、`/ping` も 200 を返すため、既存の probe では検知できない。

## 原因

起動直後のログが決定的だった。

```
INF Loading plugins... plugins=["cloudflarewarp"]
ERR Plugins are disabled because an error has occurred.
    error="unable to set up plugins environment: unable to install plugin cloudflarewarp:
    unable to download plugin github.com/BetterCorp/cloudflarewarp:
    failed to call service: Get \"https://plugins.traefik.io/public/download/github.com/BetterCorp/cloudflarewarp/v1.3.3\":
    dial tcp: lookup plugins.traefik.io on 10.1.0.10:53: read: connection refused"
```

インターネット側ではなく、クラスタ内 DNS (CoreDNS) が未 Ready であることが引き金だった。ノード起動直後は Cilium が `429 putEndpointIdTooManyRequests` を返しており、CNI の endpoint 作成が詰まっている渦中で Traefik が先に起動している。

以降の連鎖は次のとおり。

1. Traefik はプラグイン取得を起動時に一度だけ行い、リトライしない
2. 失敗すると `Plugins are disabled` となり、プラグインなしでそのまま正常起動する
3. `cloudflarewarp` を使う `trust-cloudflare-ips` が「存在しない middleware」になる
4. これは個別の IngressRoute ではなく `ports.websecure.http.middlewares` でエントリポイントに付けているため、`websecure` の全ルーターが読み込み拒否される
5. 結果、全ホストが 404。`/ping` は 200 のままなので probe は素通しする

なお `plugins-storage` の PVC は空だった。Traefik はプラグイン取得に失敗すると storage をリセットするため、キャッシュは「守るべき障害」でちょうど失われ、毎回ネットワークが必要になる。

## 対応

Traefik 3.7 が持つ `--experimental.abortonpluginfailure` を有効にする。

```
--experimental.abortonpluginfailure  (Default: "false")
    Defines whether all plugins must be loaded successfully for Traefik to start.
```

プラグインを読めなければ Traefik は起動時に終了し、kubelet が backoff 付きで再起動する。DNS 復旧後に自動的に正常化し、404 を返す Ready な Pod が生まれる余地がなくなる。

probe を拡張してプラグインの状態を検査する案も検討したが、`api.insecure` が無効なため Pod 内から `/api/*` は 404 で参照できず、API を公開するか新たなルーターを追加する必要があった。追加コンポーネントなしで同じ効果が得られる本方式を採った。

### トレードオフ

ノード再起動時は DNS が戻るまで CrashLoopBackOff（最大 5 分の backoff）となり、その間クライアントは 404 ではなく接続拒否 / Cloudflare 52x を見る。無言の 404 が継続するより検知可能かつ自動回復する点を優先した。

なお起動時に plugins.traefik.io が到達可能である必要は残る。これを解消するには `experimental.localPlugins` + initContainer によるキャッシュへの移行が必要で、部品が増えるため本 PR には含めない。

## 検証

### 1. レンダリング結果

```console
$ kustomize build --enable-helm k8s/system/traefik/lily | grep -i "experimental"
        - --experimental.plugins.cloudflarewarp.moduleName=github.com/BetterCorp/cloudflarewarp
        - --experimental.plugins.cloudflarewarp.version=v1.3.3
        - --experimental.abortonpluginfailure=true
```

### 2. フラグの挙動（DNS 到達不能を再現）

到達しない DNS サーバーを指定した Traefik v3.7.10 コンテナで、フラグの有無を対比した。

`abortOnPluginFailure: true` — 起動を中止し、非ゼロで終了する。

```console
$ docker run --rm --dns 192.0.2.1 docker.io/traefik:v3.7.10 \
    --experimental.plugins.cloudflarewarp.modulename=github.com/BetterCorp/cloudflarewarp \
    --experimental.plugins.cloudflarewarp.version=v1.3.3 \
    --experimental.abortonpluginfailure=true \
    --entrypoints.web.address=:8000; echo "exit=$?"
ERR Command error error="command traefik error: plugin: failed to create plugin builder: unable to set up plugins environment: unable to install plugin cloudflarewarp: unable to download plugin github.com/BetterCorp/cloudflarewarp: failed to call service: Get \"https://plugins.traefik.io/public/download/github.com/BetterCorp/cloudflarewarp/v1.3.3\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
exit=1
```

既定（`false`）— プラグインを無効化したまま起動し続ける。これが今回の障害そのものである。

```console
$ timeout 60 docker run --rm --dns 192.0.2.1 docker.io/traefik:v3.7.10 \
    （--experimental.abortonpluginfailure を外して同上）
ERR Plugins are disabled because an error has occurred. error="..." plugins=["cloudflarewarp"]
exit=124   # timeout による強制終了 = 起動し続けていた
```

### 3. 実クラスタの before / after

before（障害発生時）— `websecure` の全ルーター分の `invalid middleware` が出力され、`plugins-storage` は空。

```console
$ ls -la /mnt/local/traefik/plugins-storage/archives
total 8
drwxr-xr-x 2 65532 65532 4096 Aug 16 13:35 .
drwxr-xr-x 4 65532 65532 4096 Aug 16 13:35 ..
```

after（`kubectl rollout restart` による復旧後）

```console
$ kubectl logs -n traefik traefik-747f49c99f-qll6s | grep -i plugin
INF Loading plugins... plugins=["cloudflarewarp"]
INF Plugins loaded. plugins=["cloudflarewarp"]

$ for p in $(kubectl get pod -n traefik -l app.kubernetes.io/name=traefik -o name); do echo -n "$p: "; kubectl logs -n traefik $p | grep -c "invalid middleware"; done
pod/traefik-747f49c99f-nw85j: 0
pod/traefik-747f49c99f-qll6s: 0

$ kubectl logs -n traefik -l app.kubernetes.io/name=traefik --tail=200 | grep -o '"DownstreamStatus":[0-9]*' | sort | uniq -c | sort -rn
    200 "DownstreamStatus":200
      8 "DownstreamStatus":302
      3 "DownstreamStatus":303
      1 "DownstreamStatus":304
```

404 は消滅している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
