### PR TITLE
chore(cilium): lily の endpoint-create API の待機上限を延ばす

### DIFF
--- a/k8s/system/cilium/lily/kustomization.yaml
+++ b/k8s/system/cilium/lily/kustomization.yaml
@@ -21,6 +21,15 @@ helmCharts:
       enableIPv6Masquerade: true
       envoy:
         enabled: false
+      # endpoint-create API の既定は rate-limit 0.5/s, parallel-requests 4,
+      # max-wait-duration 15s。lily は 160 Pod が 1 ノードに載っているため
+      # ノード再起動時に endpoint 作成が殺到し、15 秒待ちきれなかった CNI ADD が
+      # 429 putEndpointIdTooManyRequests で落ちる。kubelet が sandbox 作成を
+      # backoff 付きでリトライするので最終的には収束するが、その間 Pod の起動順が
+      # 大きく乱れる。待たされること自体は害がないため、まず待機上限のみ緩める。
+      # https://docs.cilium.io/en/stable/configuration/api-rate-limiting/
+      extraConfig:
+        api-rate-limit: endpoint-create=max-wait-duration:2m
       hostPort:
         enabled: true
       hubble:


### PR DESCRIPTION
## 背景

lily のノード起動直後、Pod の sandbox 作成が次のエラーで失敗する。

```
Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox ...:
error adding pod traefik_traefik-... to CNI network "cilium":
plugin type="cilium-cni" failed (add): unable to create endpoint:
[PUT /endpoint/{id}][429] putEndpointIdTooManyRequests
```

Cilium の `endpoint-create` API には既定で次のレート制限がかかっている（[API Rate Limiting](https://docs.cilium.io/en/stable/configuration/api-rate-limiting/)）。

| パラメータ | 既定値 |
| --- | --- |
| rate-limit | 0.5/s |
| rate-burst | 4 |
| parallel-requests | 4 |
| max-wait-duration | 15s |

lily は 160 Pod が 1 ノードに載っているため、ノード再起動でこれが一斉に endpoint 作成へ殺到する。0.5/s では捌ききるのに 5 分以上かかり、`max-wait-duration: 15s` を超えたものが 429 になる。

```console
$ kubectl get pod -A --field-selector spec.nodeName=lily | tail -n +2 | wc -l
160
```

## 影響

429 を受けた CNI ADD は kubelet が backoff 付きでリトライするため、最終的には収束する。問題は収束するまでの間に Pod の起動順が大きく乱れることで、実際に CoreDNS より先に Traefik が起動し、プラグインの取得に失敗して全ホストが 404 を返す障害が発生した（#10030 で別途対処）。

## 対応

待たされること自体は害がないため、まず `max-wait-duration` のみ 2 分に延ばす。

```yaml
extraConfig:
  api-rate-limit: endpoint-create=max-wait-duration:2m
```

`parallel-requests` や `rate-limit` を上げる案もあるが、lily は 8 CPU であり、BPF map の更新が実際のボトルネックであれば並列度を上げてもトータルの収束時間は縮まらない。まず待機上限のみを緩め、収束が依然遅い場合に改めて検討する。

なお本変更は 429 の発生を抑えて収束を速めるものであり、Pod の起動順序を保証するものではない。順序に依存しない作りにすることは各コンポーネント側の責務とする。

## 検証

### レンダリング結果

`cilium-config` ConfigMap にキーが入ることを確認した。

```console
$ kustomize build --enable-helm k8s/system/cilium/lily | grep -B2 -A1 "api-rate-limit"
data:
  agent-not-ready-taint-key: node.cilium.io/agent-not-ready
  api-rate-limit: endpoint-create=max-wait-duration:2m
  auto-direct-node-routes: "true"
```

### パラメータ名の妥当性

`max-wait-duration` が v1.20.0 に実在し、かつ未知のパラメータ名がサイレントに無視されないことを [pkg/rate/api_limiter.go](https://github.com/cilium/cilium/blob/v1.20.0/pkg/rate/api_limiter.go) で確認した。

```go
case "max-wait-duration":
    maxWaitDuration, err := time.ParseDuration(value)
    if err != nil {
        return fmt.Errorf("unable to parse duration %q: %w", value, err)
    }
    p.MaxWaitDuration = maxWaitDuration
```

```go
default:
    return fmt.Errorf("unknown rate limiting option %q", key)
```

設定を誤れば cilium-agent が起動時に失敗するため、無言で効かないという状態にはならない。

## 適用時の注意

`cilium-config` ConfigMap の変更は cilium-agent の再起動まで反映されない。Argo CD の sync 後に次を実行する必要がある。ネットワークの瞬断を伴うため、実施タイミングに注意すること。

```console
$ kubectl rollout restart daemonset/cilium -n kube-system
```

## 未検証事項

- 実クラスタへの適用と、適用後に 429 が実際に減るかの確認は未実施。効果の確認にはノード再起動を要するため、次回の再起動時に `kubectl get events -A | grep TooManyRequests` で比較する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)