### PR TITLE
feat(gateway-api): lily の Gateway API CRD を v1.5.1 に更新して IaC 管理下に置く

### DIFF
--- a/k8s/system/argo-cd/resources/application/lily.yaml
+++ b/k8s/system/argo-cd/resources/application/lily.yaml
@@ -240,6 +240,12 @@ spec:
             namespace: external-dns
             path: k8s/system/external-dns
             project: system
+          # CRD のみ。destination.namespace は cluster-scoped リソースには
+          # 使われないが、ApplicationSet の template が要求するため指定する。
+          - name: gateway-api
+            namespace: kube-system
+            path: k8s/system/gateway-api
+            project: system
           - name: mackerel-operator
             namespace: mackerel-operator
             path: k8s/system/mackerel-operator

--- a/k8s/system/gateway-api/kustomization.yaml
+++ b/k8s/system/gateway-api/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  # CRD が大きく、client-side apply では last-applied-configuration が
+  # annotation の上限 (262,144 bytes) を超える。また既存の CRD は手動で
+  # apply されており Argo CD の管理外にあるため、adopt の際に
+  # フィールドの衝突を避ける必要がある。
+  argocd.argoproj.io/sync-options: ServerSideApply=true
+
+# Traefik v3.7 は experimentalChannel なしで TLSRoute を watch する。TLSRoute が
+# standard channel に入ったのは Gateway API v1.5.0 であり、それ以前の CRD では
+# Traefik が tlsroutes を list できず watch エラーを出し続ける。
+#
+# v1.6.x にしない理由: Traefik v3.7 は TCPRoute を v1alpha2 で watch するが、
+# v1.6.0 で TCPRoute は standard channel の v1 に移った。TCPRoute を使う場合は
+# experimental channel が必要になる。lily は TCPRoute を使っていないため、
+# Traefik v3.7 がサポートする v1.5.1 に留める。
+# https://doc.traefik.io/traefik/v3.7/migrate/v3/
+resources:
+  - github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.5.1

--- a/k8s/system/gateway-api/kustomization.yaml
+++ b/k8s/system/gateway-api/kustomization.yaml
@@ -1,13 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-commonAnnotations:
-  # CRD が大きく、client-side apply では last-applied-configuration が
-  # annotation の上限 (262,144 bytes) を超える。また既存の CRD は手動で
-  # apply されており Argo CD の管理外にあるため、adopt の際に
-  # フィールドの衝突を避ける必要がある。
-  argocd.argoproj.io/sync-options: ServerSideApply=true
-
 # Traefik v3.7 は experimentalChannel なしで TLSRoute を watch する。TLSRoute が
 # standard channel に入ったのは Gateway API v1.5.0 であり、それ以前の CRD では
 # Traefik が tlsroutes を list できず watch エラーを出し続ける。
@@ -19,3 +12,10 @@ commonAnnotations:
 # https://doc.traefik.io/traefik/v3.7/migrate/v3/
 resources:
   - github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.5.1
+
+commonAnnotations:
+  # CRD が大きく、client-side apply では last-applied-configuration が
+  # annotation の上限 (262,144 bytes) を超える。また既存の CRD は手動で
+  # apply されており Argo CD の管理外にあるため、adopt の際に
+  # フィールドの衝突を避ける必要がある。
+  argocd.argoproj.io/sync-options: ServerSideApply=true


### PR DESCRIPTION
## 事象

lily の Traefik が起動以降、数十秒間隔で次のエラーを出し続けている。

```
E0816 13:44:47.018054 1 reflector.go:227] "Failed to watch" err="failed to list *v1.TLSRoute:
the server could not find the requested resource (get tlsroutes.gateway.networking.k8s.io)"
logger="UnhandledError" type="*v1.TLSRoute"
```

## 原因

`providers.kubernetesGateway.experimentalChannel` は既定の `false` のままだが、[Traefik v3.7 のマイグレーションガイド](https://doc.traefik.io/traefik/v3.7/migrate/v3/)にあるとおり、v3.7.0 で TLSRoute は standard channel に卒業したものとして扱われ、`experimentalChannel` なしで watch されるようになった。

一方、lily に導入されている Gateway API CRD は **v1.4.0 の standard channel** であり、tlsroutes を含まない。

```console
$ kubectl get crd | grep gateway.networking.k8s.io
backendtlspolicies.gateway.networking.k8s.io   2025-11-13T20:46:54Z
gatewayclasses.gateway.networking.k8s.io       2024-10-26T17:00:08Z
gateways.gateway.networking.k8s.io             2024-10-26T17:00:07Z
grpcroutes.gateway.networking.k8s.io           2024-10-26T17:00:07Z
httproutes.gateway.networking.k8s.io           2024-10-26T17:00:08Z
referencegrants.gateway.networking.k8s.io      2024-10-26T17:00:08Z

$ kubectl get crd gateways.gateway.networking.k8s.io \
    -o jsonpath="{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version} {.metadata.annotations.gateway\.networking\.k8s\.io/channel}"
v1.4.0 standard
```

各バージョンの standard channel に含まれる CRD を確認したところ、TLSRoute が入ったのは v1.5.0 からだった。

```console
$ for v in v1.4.0 v1.5.1 v1.6.1; do
    echo "### $v"
    curl -sfL "https://github.com/kubernetes-sigs/gateway-api/releases/download/$v/standard-install.yaml" \
      | grep -E "^  name: .*\.gateway\.networking\.k8s\.io" | sed 's/^  name: //' | tr '\n' ' '; echo
  done
### v1.4.0
backendtlspolicies gatewayclasses gateways grpcroutes httproutes referencegrants
### v1.5.1
backendtlspolicies gatewayclasses gateways grpcroutes httproutes listenersets referencegrants tlsroutes safe-upgrades
### v1.6.1
backendtlspolicies gatewayclasses gateways grpcroutes httproutes listenersets referencegrants tcproutes tlsroutes udproutes safe-upgrades
```

さらに v1.5.1 の tlsroutes は `v1` を serve しており、Traefik が watch している `*v1.TLSRoute` と一致する。

```console
$ python3 -c "...(standard-install.yaml をパース)"
httproutes.gateway.networking.k8s.io -> ['v1', 'v1beta1'] channel= standard
tlsroutes.gateway.networking.k8s.io -> ['v1', 'v1alpha2', 'v1alpha3'] channel= standard
```

## 対応

Gateway API CRD を v1.5.1 の standard channel に更新する。併せて、これまで手動 apply されて Argo CD の管理外にあった CRD を ApplicationSet に登録し、IaC 管理下に置く。

### v1.6.x を選ばない理由

Traefik v3.7 は TCPRoute を `v1alpha2` で watch するが、v1.6.0 で TCPRoute は standard channel の `v1` に移った。TCPRoute を使う場合は experimental channel の CRD が必要になる。lily は TCPRoute を使っていないため、Traefik v3.7 が公式にサポートする v1.5.1 に留める。

```console
$ kubectl get gateway -A
NAMESPACE   NAME              CLASS     ADDRESS   PROGRAMMED   AGE
traefik     traefik-gateway   traefik             True         209d

$ kubectl get httproute -A
No resources found
```

### ServerSideApply について

CRD が大きく client-side apply では `last-applied-configuration` が annotation の上限 (262,144 bytes) を超えるため、`argocd.argoproj.io/sync-options: ServerSideApply=true` を付与している。既存の CRD が手動 apply 由来でありフィールドの衝突を避ける必要がある点も理由のひとつ。

## 検証

### 他の Application と競合しないこと

`FailOnSharedResource=true` が設定されているため、Gateway API CRD を出力する Application が他にないことを確認した。

```console
$ for d in k8s/system/*/; do
    out=$(kustomize build --enable-helm "$d" 2>/dev/null | grep -c "^  name: .*gateway.networking.k8s.io")
    [ "$out" != "0" ] && echo "$d: $out"
  done
k8s/system/gateway-api/: 10
```

既存の CRD には `argocd.argoproj.io/tracking-id` が付いておらず、どの Application にも属していない。

### マニフェストのビルド（CI と同一）

```console
$ go run ./cmd/build-manifests
...
level=INFO msg="✅ kustomize build succeeded" root=k8s/system/gateway-api
...
exit=0
```

### server-side dry-run

実クラスタに対して受理されることを確認した。

```console
$ kustomize build k8s/system/gateway-api | kubectl apply --server-side --dry-run=server -f -
customresourcedefinition.apiextensions.k8s.io/backendtlspolicies.gateway.networking.k8s.io serverside-applied (server dry run)
customresourcedefinition.apiextensions.k8s.io/gatewayclasses.gateway.networking.k8s.io serverside-applied (server dry run)
customresourcedefinition.apiextensions.k8s.io/gateways.gateway.networking.k8s.io serverside-applied (server dry run)
customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io serverside-applied (server dry run)
customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.io serverside-applied (server dry run)
customresourcedefinition.apiextensions.k8s.io/listenersets.gateway.networking.k8s.io serverside-applied (server dry run)
customresourcedefinition.apiextensions.k8s.io/referencegrants.gateway.networking.k8s.io serverside-applied (server dry run)
customresourcedefinition.apiextensions.k8s.io/tlsroutes.gateway.networking.k8s.io serverside-applied (server dry run)
validatingadmissionpolicy.admissionregistration.k8s.io/safe-upgrades.gateway.networking.k8s.io serverside-applied (server dry run)
validatingadmissionpolicybinding.admissionregistration.k8s.io/safe-upgrades.gateway.networking.k8s.io serverside-applied (server dry run)
```

`failed to migrate kubectl.kubernetes.io/last-applied-configuration` の警告が出るが、これは `kubectl` が既存の client-side apply 由来の annotation を移行しようとして `argocd-controller` と衝突したものであり、非致命的である旨がメッセージに明記されている。全リソースは `serverside-applied` として受理されている。

## sync 後に確認すること

Traefik の再起動は不要で、reflector が数十秒間隔でリトライするため自然に解消するはずである。

```console
$ kubectl get tlsroute -A
$ kubectl logs -n traefik -l app.kubernetes.io/name=traefik --since=5m | grep -c TLSRoute
```

v1.5.1 では `listenersets` と `safe-upgrades` の ValidatingAdmissionPolicy が新たに入るため、Traefik のログに新規の watch エラーや権限エラーが出ていないかも併せて確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)