### PR TITLE
fix(konomitv): ライブ視聴が失敗する digest を 1 つ前に戻す

### DIFF
--- a/k8s/apps/konomitv/lily/resources/deployment.yaml
+++ b/k8s/apps/konomitv/lily/resources/deployment.yaml
@@ -15,7 +15,11 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/tsukumijima/konomitv:latest@sha256:477c0d5f8b4253b3fd5a6561f0bc287f5a3dac4d141e96bf83397f901da84ce3
+          # latest (477c0d5) は --adapt-resolution を渡すサーバーコードと、そのオプションを持たない
+          # QSVEncC 8.16 を同梱しており、ライブ視聴時にエンコーダーが即座に落ちる。
+          # 上流はオプション導入 (fc98a36) の 4 日後に QSVEncC を 8.26 へ更新した (8cb8df8) が、
+          # まだイメージを再ビルドしていない。再ビルド後の Renovate PR で追従する。
+          image: ghcr.io/tsukumijima/konomitv:latest@sha256:9619cd20262fb08bb1c4cf0464b06927f86742447bcc9379cb245daeb556d941
           volumeMounts:
             - name: config
               mountPath: /code/config.yaml


### PR DESCRIPTION
## 事象

KonomiTV でライブ視聴を開始しても、読み込み中のまま再生が始まらない。
ブラウザ側には `Status: Offline / Detail: ライブストリームの再起動に失敗しました。(E-17)` が出る。

## 原因

サーバーログの該当箇所。

```
[Live: gr011-1-1080p] Acquired a tuner from Mirakurun.
[Live: gr011-1-1080p] Tuner: PX-Q3PE4_D0_T0 / Type: GR / Acquired in 3.03 seconds
[Live: gr011-1-1080p] [Status: Restart] エンコーダーが強制終了されました。エンコードタスクを再起動しています… (ER-06)
[Live: gr011-1-1080p] [QSVEncC] Error: Unknown option: --adapt-resolution
```

チューナーの確保は成功しており、落ちているのはエンコーダーの起動である。
KonomiTV が組み立てるコマンドに `--adapt-resolution 1920x1080` が含まれるが、
同梱の QSVEncC はこのオプションを持たない。

```
$ QSVEncC.elf --version
QSVEncC (x64) 8.16 (r4146) by rigaya, Jun 17 2026 11:27:36 (gcc 9.4.0/Linux)

$ QSVEncC.elf --help | grep -c adapt-resolution
0
```

上流の履歴を見ると、サーバー側が先行して新オプションを使い始めていた。

| コミット | 日付 (UTC) | 内容 |
| --- | --- | --- |
| `fc98a36` | 08-14 12:38 | `[Server][Streams/EncodingTask] HWEncC の可変解像度対応を反映` |
| `8cb8df8` | 08-18 15:02 | `[GitHub][workflows] QSVEncC を 8.26 に…更新` |

現在の digest `477c0d5` はこの 2 つの間にビルドされたものにあたる。
`latest` タグは本 PR の作成時点でも `477c0d5` を指しており、上流は QSVEncC 更新後の再ビルドをまだ行っていない。

## 対応

1 つ前の digest `9619cd2` に戻す。これは 08-13 のビルドで `fc98a36` より前のため、この問題を踏まない。
上流が再ビルドすれば Renovate が次の PR を出すので、その時点で追従する。戻した理由はマニフェストにコメントで残した。

## 補足

同じ時間帯に Mahiron を 5 系へ移行した (#10060) が、本件とは無関係である。
KonomiTV の Pod が入れ替わったのは 15:54、Mahiron の切替は 17:59 で、事象の発生は移行の 2 時間前にあたる。
上記のログのとおり Mahiron からのチューナー確保は成功している。

## 検証

マージ後に実画面でライブ視聴を確認し、結果を本 PR に追記する。