### PR TITLE
fix(konomitv): ライブ視聴が失敗するため v0.14.1 に固定する

### DIFF
--- a/k8s/apps/konomitv/lily/resources/deployment.yaml
+++ b/k8s/apps/konomitv/lily/resources/deployment.yaml
@@ -15,11 +15,16 @@ spec:
     spec:
       containers:
         - name: app
-          # latest (477c0d5) は --adapt-resolution を渡すサーバーコードと、そのオプションを持たない
+          # latest は --adapt-resolution を渡すサーバーコードと、そのオプションを持たない
           # QSVEncC 8.16 を同梱しており、ライブ視聴時にエンコーダーが即座に落ちる。
           # 上流はオプション導入 (fc98a36) の 4 日後に QSVEncC を 8.26 へ更新した (8cb8df8) が、
-          # まだイメージを再ビルドしていない。再ビルド後の Renovate PR で追従する。
-          image: ghcr.io/tsukumijima/konomitv:latest@sha256:9619cd20262fb08bb1c4cf0464b06927f86742447bcc9379cb245daeb556d941
+          # まだイメージを再ビルドしていない。
+          #
+          # latest の過去の digest はレジストリに残っていないため戻せない。
+          # リリースビルドはサーバーコードと同梱エンコーダーの組み合わせが整合しており、
+          # マイグレーションも master と同一 (11_20260604000000_update.py で終端) なので、
+          # 上流が再ビルドするまでリリースタグに固定する。
+          image: ghcr.io/tsukumijima/konomitv:v0.14.1@sha256:3c27362b49da1047593ef933d9ffad247f965627507c0c6c3ec0269b06e6e8b8
           volumeMounts:
             - name: config
               mountPath: /code/config.yaml


### PR DESCRIPTION
#10064 の続き。digest 戻しが機能しなかったため、リリースタグへの固定に切り替える。

## 経緯

#10064 で `latest` の 1 つ前の digest (`9619cd2`) に戻したが、ImagePullBackOff になった。

```
Failed to pull image "ghcr.io/tsukumijima/konomitv:latest@sha256:9619cd2...":
  reading manifest sha256:9619cd2... in ghcr.io/tsukumijima/konomitv: manifest unknown
```

レジストリを確認したところ、このリポジトリで過去に追跡していた digest はいずれも残っていなかった。

| マージ日 | digest | HTTP |
| --- | --- | --- |
| 08-14 | `9619cd2` | 404 |
| 08-12 | `0354396` | 404 |
| 08-09 | `08e8446` | 404 |
| 08-08 | `6e4dda3` | 404 |
| 08-08 | `ef79a06` | 404 |

`latest` はタグの付いていない過去のマニフェストを保持していない。digest 戻しはこのイメージでは使えない。

なお旧 Pod が Running のまま残っていたため、ライブ視聴以外の機能は停止していない。

## 対応

リリースタグ `v0.14.1` (2026-06-18, digest `3c27362b`) に固定する。レジストリに存在することを確認済み。

リリースビルドはサーバーコードと同梱エンコーダーの組み合わせが整合している。
`v0.14.1` の `LiveEncodingTask.py` に `--adapt-resolution` は含まれない (master には 3 箇所ある)。

## DB 互換性

`/code/server/data` は永続ボリュームであり、リリースを遡る際はマイグレーションの整合を確認する必要がある。
実 DB に適用済みの最新マイグレーションと、両 ref のマイグレーション一覧は次のとおりで、すべて一致している。

```
適用済み (aerich): 11_20260604000000_update.py
v0.14.1          : ... 9_20260528010000 / 10_20260530010000 / 11_20260604000000_update.py
master           : ... 9_20260528010000 / 10_20260530010000 / 11_20260604000000_update.py
```

スキーマの分岐はないため、戻してもマイグレーションの不整合は起きない。

## 今後

`latest` 追従からリリースタグ追従への方針変更にあたる。
上流が QSVEncC 8.26 を含むイメージを再ビルドすれば `latest` に戻せる。
次のリリースが出れば Renovate がタグ更新の PR を出す。

## 検証

マージ後に実画面でライブ視聴を確認し、結果を本 PR に追記する。