### PR TITLE
fix(konomitv): Mahiron 5 系で起動できない問題に対処する

### DIFF
--- a/k8s/apps/konomitv/lily/config/config.yaml
+++ b/k8s/apps/konomitv/lily/config/config.yaml
@@ -8,8 +8,11 @@ general:
   debug: true
   debug_encoder: true
 
-  encoder: QSVEncC
-  mirakurun_url: "http://app.mahiron:40772/"
+  # 同梱の QSVEncC 8.16 が --adapt-resolution を解釈できずライブ視聴が失敗するため、
+  # 上流がイメージを再ビルドするまでソフトウェアエンコードにフォールバックする
+  encoder: FFmpeg
+  # Server レスポンスヘッダーを補うため Traefik を経由する (resources/mahiron.yaml を参照)
+  mirakurun_url: "http://mahiron-internal/"
 
 tv:
   max_alive_time: 60

--- a/k8s/apps/konomitv/lily/kustomization.yaml
+++ b/k8s/apps/konomitv/lily/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./resources/deployment.yaml
   - ./resources/dns.yaml
   - ./resources/ingress.yaml
+  - ./resources/mahiron.yaml
   - ./resources/namespace.yaml
   - ./resources/service.yaml
 

--- a/k8s/apps/konomitv/lily/resources/deployment.yaml
+++ b/k8s/apps/konomitv/lily/resources/deployment.yaml
@@ -15,16 +15,14 @@ spec:
     spec:
       containers:
         - name: app
-          # latest は --adapt-resolution を渡すサーバーコードと、そのオプションを持たない
-          # QSVEncC 8.16 を同梱しており、ライブ視聴時にエンコーダーが即座に落ちる。
-          # 上流はオプション導入 (fc98a36) の 4 日後に QSVEncC を 8.26 へ更新した (8cb8df8) が、
-          # まだイメージを再ビルドしていない。
+          # latest はサーバーコードが QSVEncC に --adapt-resolution を渡すが、同梱の QSVEncC 8.16 は
+          # このオプションを持たない。QSVEncC を使うとライブ視聴でエンコーダーが起動直後に落ちるため、
+          # 上流が QSVEncC 8.26 を含むイメージを再ビルドするまで config.yaml で FFmpeg を使う。
           #
-          # latest の過去の digest はレジストリに残っていないため戻せない。
-          # リリースビルドはサーバーコードと同梱エンコーダーの組み合わせが整合しており、
-          # マイグレーションも master と同一 (11_20260604000000_update.py で終端) なので、
-          # 上流が再ビルドするまでリリースタグに固定する。
-          image: ghcr.io/tsukumijima/konomitv:v0.14.1@sha256:3c27362b49da1047593ef933d9ffad247f965627507c0c6c3ec0269b06e6e8b8
+          # リリースタグ v0.14.1 への固定も試したが、こちらは Mirakurun のバージョンを
+          # /api/tuners の Server レスポンスヘッダーから判定する。Mahiron 5 系はこのヘッダーを
+          # 返さないため設定バリデーションで弾かれ、KonomiTV が起動しない。
+          image: ghcr.io/tsukumijima/konomitv:latest@sha256:477c0d5f8b4253b3fd5a6561f0bc287f5a3dac4d141e96bf83397f901da84ce3
           volumeMounts:
             - name: config
               mountPath: /code/config.yaml

--- a/k8s/apps/konomitv/lily/resources/mahiron.yaml
+++ b/k8s/apps/konomitv/lily/resources/mahiron.yaml
@@ -1,0 +1,11 @@
+# Mahiron の Service を直接引かず、Server レスポンスヘッダーを補う Traefik の経路を経由する。
+# 理由は k8s/apps/mahiron/lily/resources/ingress.yaml の Middleware のコメントを参照。
+# この Service 名がそのまま Host ヘッダーになり、Traefik 側の Host 一致条件と対応する。
+apiVersion: v1
+kind: Service
+metadata:
+  name: mahiron-internal
+
+spec:
+  type: ExternalName
+  externalName: traefik.traefik.svc.cluster.local

--- a/k8s/apps/mahiron/lily/resources/ingress.yaml
+++ b/k8s/apps/mahiron/lily/resources/ingress.yaml
@@ -54,3 +54,42 @@ spec:
     realm: Access Restricted
     removeHeader: true
     secret: basic-auth-credentials
+
+---
+# KonomiTV は Mirakurun のバージョンを /api/tuners の Server レスポンスヘッダーから判定し、
+# 取得できないと「Mirakurun の URL ではない」として起動を拒否する。
+# 元々は /api/version を叩いていたが、Mirakurun 4.0.0-beta.5 以下に同 API で録画中の TS が
+# ドロップするバグがあったため、KonomiTV 側が 850e559 でヘッダー参照に切り替えた経緯がある。
+#
+# Mahiron 4 系は Server: Mahiron/<version> を返していたが、5 系は返さない。
+# 上流が対応するまで、内部向けの経路でヘッダーを補う。
+# 値はバージョン表示にしか使われないため、パッチ更新で陳腐化しない粒度にとどめる。
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mirakurun-compat-server-header
+
+spec:
+  headers:
+    customResponseHeaders:
+      Server: Mahiron/5.x
+
+---
+# クラスタ内から Mirakurun 互換クライアントが参照するための経路。
+# 参照側は Traefik を指す ExternalName Service を置き、その名前が Host ヘッダーになる。
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: route-internal
+
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: Host(`mahiron-internal`)
+      services:
+        - name: app
+          port: 40772
+      middlewares:
+        - name: mirakurun-compat-server-header


### PR DESCRIPTION
#10064 / #10066 の続き。KonomiTV が起動できない状態が続いているため、根本の非互換に対処する。

## 何が起きていたか

障害は 2 つ重なっていた。

**1. KonomiTV が Mahiron 5 系に対して起動できない**

KonomiTV は `/api/tuners` の `Server` レスポンスヘッダーからバックエンドのバージョンを判定し、
取得できないと設定バリデーションで弾く。

```python
server_header = response.headers.get('server', '').lower()
version_info = server_header.split('/')[-1] if '/' in server_header else 'unknown'
...
if response.status_code != 200 or not isinstance(response_json, list) or version_info == 'unknown':
    raise ValueError()
```

```
ERROR:    設定内容が不正なため、KonomiTV を起動できません。
ERROR:    1 validation error for ServerSettings
general.mirakurun_url
  Value error, http://app.mahiron:40772/ は Mirakurun の URL ではありません。
```

Mahiron 4 系は `Server: Mahiron/<version>` を返していたが、5 系は返さない。

この判定は KonomiTV `850e559` (2025-10-26) で入った。
Mirakurun 4.0.0-beta.5 以下に「`/api/version` を叩くと録画中の TS がドロップする」バグがあり、
バージョン取得先を `/api/version` から `/api/tuners` + `Server` ヘッダーへ移した際の副作用である。
v0.13.0 以降と master が該当し、v0.12.0 以前は `/api/version` を使うため影響しない。

**2. QSVEncC のオプション不整合でライブ視聴が失敗する (#10064)**

`latest` のサーバーコードは `--adapt-resolution` を渡すが、同梱の QSVEncC 8.16 はこのオプションを持たない。

```
[Live: gr011-1-1080p] [QSVEncC] Error: Unknown option: --adapt-resolution
```

1 は移行に起因し、2 は移行と無関係な KonomiTV 側の問題である。
2 の回避のため `latest` の過去 digest への切り戻し (#10064) とリリースタグ固定 (#10066) を試したが、
前者は digest がレジストリに残っておらず ImagePullBackOff、後者は 1 の判定で起動できず、いずれも失敗した。

## 対応

**1 に対して**: 内部向けの経路を Traefik に用意し、Middleware で `Server` ヘッダーを補う。

- `mahiron` namespace に Middleware と `web` エントリーポイントの IngressRoute を追加
- `konomitv` namespace に Traefik を指す ExternalName Service を追加し、`mirakurun_url` をそこへ向ける
- Service 名がそのまま Host ヘッダーになり、Traefik の Host 一致条件と対応する

ヘッダーの値はバージョン表示にしか使われないため、パッチ更新で陳腐化しない粒度 (`Mahiron/5.x`) にとどめた。

**2 に対して**: `encoder` を FFmpeg に変更する。`--adapt-resolution` は `buildHWEncCOptions` の中だけで、
`buildFFmpegOptions` には現れないため回避できる。ソフトウェアエンコードになるため CPU 負荷は上がる。

イメージは #10066 で固定した v0.14.1 から `latest` に戻す。

## 副作用

`mirakurun_url` は 1 つしかないため、バリデーションだけを別経路にはできない。
KonomiTV から Mahiron への全通信 (TS ストリームを含む) が Traefik を 1 ホップ経由する。
`mahiron-api.starry.blue` は既に外部向けに TS を Traefik 経由で流しているため実績はあるが、
マージ後にストリームの疎通と安定性を確認する。

## 解消の条件

- 1: 上流 Mahiron 5 系が `Server` レスポンスヘッダーを返すようになれば、Traefik 経由をやめて直接参照に戻せる。別途 issue を立てる
- 2: 上流 KonomiTV が QSVEncC 8.26 を含むイメージを再ビルドすれば `encoder: QSVEncC` に戻せる

いずれも戻す条件をマニフェストのコメントに残した。

## 検証

マージ後に KonomiTV の起動、ライブ視聴、ストリームの安定性を実画面で確認し、結果を本 PR に追記する。