### PR TITLE
feat(epgstation): 起動不能を検出する probe を追加する

### DIFF
--- a/k8s/apps/epgstation/resources/deployment.yaml
+++ b/k8s/apps/epgstation/resources/deployment.yaml
@@ -20,31 +20,6 @@ spec:
           image: ghcr.io/slashnephy/epgstation-custom-hwaccel:master@sha256:07c7cd373935117099ba3a8f1b3db7cfbce6a978554b73c1bc7b581ce3e652ab
           ports:
             - containerPort: 8888
-          # EPGStation は Mirakurun の OpenAPI 定義を起動時に一度だけ取得して永久にキャッシュする。
-          # 定義のパス項目に parameters が無い世代を掴むと、以降 getStatus() が
-          # TypeError: p.parameters is not iterable で落ち続ける。これはリクエスト送出前に起きるうえ、
-          # ConnectionCheckModel が理由ごと catch するため、EPGStation にも Mirakurun にもログが残らない。
-          # Mirakurun 側を直しても定義は再取得されないので、再起動しない限り復帰しない。
-          #
-          # HTTP を待ち受けるサービスプロセスは checkMirakurun() の後に起動するため、
-          # この停止中は 8888 が listen しない。プローブで検出して再起動をかける。
-          startupProbe:
-            httpGet:
-              path: /api/version
-              port: 8888
-            periodSeconds: 10
-            timeoutSeconds: 5
-            # Mirakurun が本当に落ちている間の待機は正常な挙動なので、猶予を広く取る。
-            # ノード再起動時の収束に約 6 分かかるため、それを超える 10 分に設定する。
-            failureThreshold: 60
-          livenessProbe:
-            httpGet:
-              path: /api/version
-              port: 8888
-            periodSeconds: 30
-            timeoutSeconds: 5
-            # 録画中の再起動は取り逃しに直結するため、一時的な応答遅延では落とさない
-            failureThreshold: 4
           volumeMounts:
             - name: data
               mountPath: /app/data
@@ -58,11 +33,37 @@ spec:
           resources:
             limits:
               gpu.intel.com/i915: "1"
+          # 起動後の応答停止に備えるもの。起動できない状態の検出は startupProbe が担う (下記のコメントを参照)
+          livenessProbe:
+            # 録画中の再起動は取り逃しに直結するため、一時的な応答遅延では落とさない
+            failureThreshold: 4
+            httpGet:
+              path: /api/version
+              port: 8888
+            periodSeconds: 30
+            timeoutSeconds: 5
           securityContext:
             capabilities:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+          # EPGStation は Mirakurun の OpenAPI 定義を起動時に一度だけ取得して永久にキャッシュする。
+          # 定義のパス項目に parameters が無い世代を掴むと、以降 getStatus() が
+          # TypeError: p.parameters is not iterable で落ち続ける。これはリクエスト送出前に起きるうえ、
+          # ConnectionCheckModel が理由ごと catch するため、EPGStation にも Mirakurun にもログが残らない。
+          # Mirakurun 側を直しても定義は再取得されないので、再起動しない限り復帰しない。
+          #
+          # HTTP を待ち受けるサービスプロセスは checkMirakurun() の後に起動するため、
+          # この停止中は 8888 が listen しない。プローブで検出して再起動をかける。
+          startupProbe:
+            # Mirakurun が本当に落ちている間の待機は正常な挙動なので、猶予を広く取る。
+            # ノード再起動時の収束に約 6 分かかるため、それを超える 10 分に設定する。
+            failureThreshold: 60
+            httpGet:
+              path: /api/version
+              port: 8888
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: data
           hostPath:

--- a/k8s/apps/epgstation/resources/deployment.yaml
+++ b/k8s/apps/epgstation/resources/deployment.yaml
@@ -20,6 +20,31 @@ spec:
           image: ghcr.io/slashnephy/epgstation-custom-hwaccel:master@sha256:07c7cd373935117099ba3a8f1b3db7cfbce6a978554b73c1bc7b581ce3e652ab
           ports:
             - containerPort: 8888
+          # EPGStation は Mirakurun の OpenAPI 定義を起動時に一度だけ取得して永久にキャッシュする。
+          # 定義のパス項目に parameters が無い世代を掴むと、以降 getStatus() が
+          # TypeError: p.parameters is not iterable で落ち続ける。これはリクエスト送出前に起きるうえ、
+          # ConnectionCheckModel が理由ごと catch するため、EPGStation にも Mirakurun にもログが残らない。
+          # Mirakurun 側を直しても定義は再取得されないので、再起動しない限り復帰しない。
+          #
+          # HTTP を待ち受けるサービスプロセスは checkMirakurun() の後に起動するため、
+          # この停止中は 8888 が listen しない。プローブで検出して再起動をかける。
+          startupProbe:
+            httpGet:
+              path: /api/version
+              port: 8888
+            periodSeconds: 10
+            timeoutSeconds: 5
+            # Mirakurun が本当に落ちている間の待機は正常な挙動なので、猶予を広く取る。
+            # ノード再起動時の収束に約 6 分かかるため、それを超える 10 分に設定する。
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /api/version
+              port: 8888
+            periodSeconds: 30
+            timeoutSeconds: 5
+            # 録画中の再起動は取り逃しに直結するため、一時的な応答遅延では落とさない
+            failureThreshold: 4
           volumeMounts:
             - name: data
               mountPath: /app/data


### PR DESCRIPTION
## 背景

2026-08-20 に EPGStation が 56 分間起動できないまま放置され、その間の番組が頭切れになった。原因は Mirakurun (Mahiron) の OpenAPI 定義のキャッシュだった。

`mirakurun` クライアント (3.9.0-rc.4) の `call()` は `/api/docs` の OpenAPI 定義を**初回だけ**取得して `_docs` にキャッシュし、以降は再取得しない。定義のパス項目に `parameters` が無いと、`parameters = [...p.parameters, ...]` が落ちる。

```
TypeError: p.parameters is not iterable
  at Client.call (/app/node_modules/mirakurun/lib/client.js:93:36)
  at Client.getStatus (/app/node_modules/mirakurun/lib/client.js:348:32)
```

これは**リクエスト送出前**に起きるため Mirakurun 側のログに一切現れず、`ConnectionCheckModel.checkMirakurun()` が `catch (err)` で理由を捨てるため EPGStation 側にも残らない。`check mirakurun` が 1 秒ごとに出続けるだけになる。

Mirakurun 側を直しても定義は再取得されないので、**EPGStation を再起動しない限り永久に復帰しない**。

実際の時系列:

| 時刻 | 出来事 |
| --- | --- |
| 10:25:43 | EPGStation 起動、修正前の Mahiron から壊れた定義を取得しキャッシュ |
| 10:38:33 | Mahiron が `d483aa7` に更新され、定義が修正される |
| 〜11:21 | EPGStation は復帰せず、`check mirakurun` を約 3,300 回ログ |
| 11:21:54 | 手動で `rollout restart` して復旧 |

## 変更内容

`startupProbe` と `livenessProbe` を追加する。

HTTP を待ち受けるサービスプロセスは `checkMirakurun()` の**後**に起動する (`dist/index.js` の 76 行目と 99 行目) ため、この停止中は 8888 が listen しない。HTTP プローブで確実に検出できる。

```console
$ kubectl exec -n epgstation deploy/deployment -- grep -nE 'checkMirakurun|checkDB|spawn|start service' /app/dist/index.js
76:    await connectionChecker.checkMirakurun();
78:    await connectionChecker.checkDB();
99:    const child = child_process.spawn(process.argv[0], [path.join(__dirname, 'model', 'service', 'ServiceExecutor.js')], {
122:    log.system.info(`start service pid: ${child.pid}`);
```

`failureThreshold: 60` × `periodSeconds: 10` で猶予は 10 分。Mirakurun が本当に落ちている間の待機は正常な挙動であり、ノード再起動時の収束に約 6 分かかるため、それを超える値にしている。

`livenessProbe` は起動後の応答停止に備えるもの。録画中の再起動は取り逃しに直結するため `failureThreshold: 4` (2 分) として、一時的な応答遅延では落とさない。

## 検証

### プローブ対象が安価であること

```console
$ kubectl exec -n epgstation deploy/deployment -- node -e "fetch('http://127.0.0.1:8888/api/version').then(async r=>console.log(r.status, await r.text()))"
200 {"version":"2.10.0-20260813-080742-9a805e6"}
```

### API サーバーが定義を受理すること

```console
$ kubectl apply --server-side --dry-run=server -f - <<< "$(kubectl kustomize --enable-helm k8s/apps/epgstation)"
startupProbe  {"failureThreshold": 60, "httpGet": {"path": "/api/version", "port": 8888, "scheme": "HTTP"}, "periodSeconds": 10, "successThreshold": 1, "timeoutSeconds": 5}
livenessProbe {"failureThreshold": 4, "httpGet": {"path": "/api/version", "port": 8888, "scheme": "HTTP"}, "periodSeconds": 30, "successThreshold": 1, "timeoutSeconds": 5}
```

サーバー側で黙って捨てられていないことを確認済み。

### ビルドと lint

```console
$ go run ./cmd/build-manifests
... 全 root で ✅ kustomize build succeeded (exit 0)
```

`kube-linter` はレンダリング済みの Deployment に対して比較した。`no-liveness-probe` が解消し、他の指摘は増減なし。

| | 変更前 | 変更後 |
| --- | --- | --- |
| `no-liveness-probe` | 1 | **0** |
| `no-readiness-probe` | 1 | 1 |
| `default-service-account` | 1 | 1 |
| `non-isolated-pod` | 1 | 1 |
| `run-as-non-root` | 1 | 1 |

## 未検証事項

**プローブが実際に停止状態を検出して再起動をかけるところまでは未検証。** 再現には Mirakurun を落とすか壊れた定義を配る必要があり、録画に影響するため実施していない。検出できる根拠は上記の起動順序 (8888 が listen しないこと) に基づく。

## 補足

`no-readiness-probe` は今回対象外にした。readinessProbe を足すと Pod 入れ替え中に Traefik が未起動の Pod へ流さなくなり 502 を防げるので、別途入れる価値はある。
