### PR TITLE
chore(mackerel-operator): chart を 0.3.0 に更新

### DIFF
--- a/k8s/system/mackerel-operator/kustomization.yaml
+++ b/k8s/system/mackerel-operator/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: mackerel-operator
     releaseName: mackerel-operator
     namespace: mackerel-operator
-    version: 0.2.0
+    version: 0.3.0
     repo: https://slashnephy.github.io/mackerel-operator
     includeCRDs: true
 


### PR DESCRIPTION
## 概要

mackerel-operator の Helm chart を 0.2.0 → 0.3.0 に更新する。

0.3.0 の `ExternalMonitor` CRD の変更点:

- `spec.dualstack` (`ipv4` / `ipv6` / `auto`) を追加。未設定時は Mackerel 既定の ipv4 と同じ挙動になるよう、意図的に kubebuilder default を持たない。
- `spec.headers[].valueFrom.secretKeyRef` を追加。`value` と排他で、CEL (`has(self.value) != has(self.valueFrom)`) により検証される。
- 上記に伴い、operator の ClusterRole に `secrets` の `get` / `list` / `watch` が付与される。

既存の `ExternalMonitor` (13 件) はいずれも `headers` / `dualstack` を使用していないため、マニフェスト側の変更は chart のバージョンのみ。

## 検証

### レンダリング差分 (`kustomize build --enable-helm k8s/system/mackerel-operator`)

chart バージョン以外の実質的な差分は、CRD の新フィールド・ClusterRole の secrets 権限・イメージタグの 3 点のみ。

```diff
@@ ClusterRole @@
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
@@ Deployment @@
-        image: ghcr.io/slashnephy/mackerel-operator:0.2.0
+        image: ghcr.io/slashnephy/mackerel-operator:0.3.0
```

### サーバーサイド dry-run

`kubectl apply --dry-run=server -n mackerel-operator` で全リソースが受理された。

```
customresourcedefinition.apiextensions.k8s.io/externalmonitors.mackerel.starry.blue configured (server dry run)
serviceaccount/mackerel-operator configured (server dry run)
role.rbac.authorization.k8s.io/mackerel-operator-leader-election configured (server dry run)
clusterrole.rbac.authorization.k8s.io/mackerel-operator-manager configured (server dry run)
rolebinding.rbac.authorization.k8s.io/mackerel-operator-leader-election configured (server dry run)
clusterrolebinding.rbac.authorization.k8s.io/mackerel-operator-manager configured (server dry run)
deployment.apps/mackerel-operator configured (server dry run)
onepassworditem.onepassword.com/mackerel-api-key configured (server dry run)
```

API サーバーが返した CRD を読み直し、新フィールドが pruning されずに保持されることを確認した。

```
dualstack enum: ['ipv4', 'ipv6', 'auto']
headers[].valueFrom: ['secretKeyRef']
headers[].required: ['name']
CEL rule: has(self.value) != has(self.valueFrom)
```

### `go run ./cmd/build-manifests`

全ディレクトリで成功。`k8s/system/mackerel-operator` を含め失敗なし。

## 備考

レンダリング結果に対して kube-linter を実行すると、`access-to-secrets` の指摘が 1 件増える (`ClusterRoleBinding` が secrets への read 権限を持つ ClusterRole に紐付く)。これは `valueFrom.secretKeyRef` の実装上避けられないもので、CI の kube-linter は helm chart をレンダリングしないため対象外である。抑制設定は入れていない。