### PR TITLE
feat(file-browser): FileBrowser Quantum へ移行する

### DIFF
--- a/k8s/apps/file-browser/config/config.json
+++ b/k8s/apps/file-browser/config/config.json
@@ -1,7 +1,0 @@
-{
-  "root": "/srv",
-  "address": "0.0.0.0",
-  "port": 8080,
-  "log": "stdout",
-  "database": "/data/filebrowser.db"
-}

--- a/k8s/apps/file-browser/config/config.yaml
+++ b/k8s/apps/file-browser/config/config.yaml
@@ -1,0 +1,45 @@
+server:
+  port: 8080
+  # ルートファイルシステムが読み取り専用のため、書き込み先を hostPath に逃がす
+  database: /data/database.db
+  # インデックス用 SQLite とサムネイルの置き場。再起動のたびに再インデックスしないよう永続化する
+  cacheDir: /data/cache
+  logging:
+    - levels: info|warning|error
+  sources:
+    # records_links のシンボリックリンクは /mnt/pool/records を指す。
+    # 参照先がソースのルート外に出ると解決が拒否されるため、/mnt/pool ごと 1 つのソースにする
+    - path: /mnt/pool
+      name: pool
+      # ソースが複数あるときは既定で有効にならないため、明示する
+      config:
+        defaultEnabled: true
+    - path: /capture
+      name: konomitv-capture
+      config:
+        defaultEnabled: true
+
+auth:
+  methods:
+    password:
+      enabled: false
+    # authentik の forward-auth が付与するヘッダをそのまま利用する
+    proxy:
+      enabled: true
+      header: X-authentik-username
+      logoutRedirectUrl: https://files.starry.blue/outpost.goauthentik.io/sign_out
+  # このユーザー名で初回ログインしたときに admin 権限が付与される
+  adminUsername: spica
+
+userDefaults:
+  account:
+    loginMethod: proxy
+    # admin 権限だけでは書き込みが拒否されるため、個別に許可する。
+    # ログインできるのは authentik を通過したユーザーのみなので、既定値として付与してよい
+    permissions:
+      create: true
+      delete: true
+      download: true
+      modify: true
+      realtime: true
+      share: true

--- a/k8s/apps/file-browser/config/config.yaml
+++ b/k8s/apps/file-browser/config/config.yaml
@@ -1,25 +1,6 @@
-server:
-  port: 8080
-  # ルートファイルシステムが読み取り専用のため、書き込み先を hostPath に逃がす
-  database: /data/database.db
-  # インデックス用 SQLite とサムネイルの置き場。再起動のたびに再インデックスしないよう永続化する
-  cacheDir: /data/cache
-  logging:
-    - levels: info|warning|error
-  sources:
-    # records_links のシンボリックリンクは /mnt/pool/records を指す。
-    # 参照先がソースのルート外に出ると解決が拒否されるため、/mnt/pool ごと 1 つのソースにする
-    - path: /mnt/pool
-      name: pool
-      # ソースが複数あるときは既定で有効にならないため、明示する
-      config:
-        defaultEnabled: true
-    - path: /capture
-      name: konomitv-capture
-      config:
-        defaultEnabled: true
-
 auth:
+  # このユーザー名で初回ログインしたときに admin 権限が付与される
+  adminUsername: spica
   methods:
     password:
       enabled: false
@@ -28,8 +9,27 @@ auth:
       enabled: true
       header: X-authentik-username
       logoutRedirectUrl: https://files.starry.blue/outpost.goauthentik.io/sign_out
-  # このユーザー名で初回ログインしたときに admin 権限が付与される
-  adminUsername: spica
+
+server:
+  # インデックス用 SQLite とサムネイルの置き場。再起動のたびに再インデックスしないよう永続化する
+  cacheDir: /data/cache
+  # ルートファイルシステムが読み取り専用のため、書き込み先を hostPath に逃がす
+  database: /data/database.db
+  logging:
+    - levels: info|warning|error
+  port: 8080
+  # ソースが複数あるときは既定で有効にならないため、defaultEnabled を明示する
+  sources:
+    # records_links のシンボリックリンクは /mnt/pool/records を指す。
+    # 参照先がソースのルート外に出ると解決が拒否されるため、/mnt/pool ごと 1 つのソースにする
+    - name: pool
+      config:
+        defaultEnabled: true
+      path: /mnt/pool
+    - name: konomitv-capture
+      config:
+        defaultEnabled: true
+      path: /capture
 
 userDefaults:
   account:

--- a/k8s/apps/file-browser/kustomization.yaml
+++ b/k8s/apps/file-browser/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 configMapGenerator:
   - name: app-config
     files:
-      - ./config/config.json
+      - ./config/config.yaml

--- a/k8s/apps/file-browser/resources/deployment.yaml
+++ b/k8s/apps/file-browser/resources/deployment.yaml
@@ -15,26 +15,48 @@ spec:
     spec:
       containers:
         - name: app
-          image: filebrowser/filebrowser:v2.63.23@sha256:a469ea076d4a1b4b1d86a41d130f2f536cd9da996a2b1fb39c0d7635f9d89b9a
+          image: gtstef/filebrowser:1.5.3-stable@sha256:e2ac55ccbe53d63b3f1d7d5ea5b82edf589b005a4b747b59912f97c6ba4f969e
           env:
             - name: TZ
               value: Asia/Tokyo
+            - name: FILEBROWSER_CONFIG
+              value: /config/config.yaml
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 30
+            timeoutSeconds: 5
           ports:
             - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
+          startupProbe:
+            # 初回起動時は全ソースのインデックス作成が走るため、猶予を広く取る
+            failureThreshold: 60
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
-              mountPath: /config/settings.json
+              mountPath: /config/config.yaml
               readOnly: true
-              subPath: config.json
+              subPath: config.yaml
             - name: data
               mountPath: /data
             - name: public
-              mountPath: /srv/public
+              mountPath: /mnt/pool/public
               readOnly: true
             - name: music
-              mountPath: /srv/music
+              mountPath: /mnt/pool/music
             - name: dtv-records-links
-              mountPath: /srv/dtv/records
+              mountPath: /mnt/pool/records_links
               readOnly: true
             - name: dtv-records
               mountPath: /mnt/pool/records
@@ -43,7 +65,9 @@ spec:
               mountPath: /mnt/pool/records_local
               readOnly: true
             - name: dtv-konomitv-capture
-              mountPath: /srv/dtv/konomitv-capture
+              mountPath: /capture
+            - name: tmp
+              mountPath: /tmp
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -85,6 +109,8 @@ spec:
           hostPath:
             path: /mnt/local/konomitv/data/capture
             type: Directory
+        - name: tmp
+          emptyDir: {}
       restartPolicy: Always
       securityContext:
         seccompProfile:

--- a/k8s/apps/file-browser/resources/deployment.yaml
+++ b/k8s/apps/file-browser/resources/deployment.yaml
@@ -21,28 +21,8 @@ spec:
               value: Asia/Tokyo
             - name: FILEBROWSER_CONFIG
               value: /config/config.yaml
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            periodSeconds: 30
-            timeoutSeconds: 5
           ports:
             - containerPort: 8080
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            periodSeconds: 10
-            timeoutSeconds: 5
-          startupProbe:
-            # 初回起動時は全ソースのインデックス作成が走るため、猶予を広く取る
-            failureThreshold: 60
-            httpGet:
-              path: /health
-              port: 8080
-            periodSeconds: 10
-            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /config/config.yaml
@@ -68,6 +48,18 @@ spec:
               mountPath: /capture
             - name: tmp
               mountPath: /tmp
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -76,6 +68,14 @@ spec:
             readOnlyRootFilesystem: true
             runAsGroup: 1000
             runAsUser: 1000
+          startupProbe:
+            # 初回起動時は全ソースのインデックス作成が走るため、猶予を広く取る
+            failureThreshold: 60
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: config
           configMap:

--- a/renovate.json5
+++ b/renovate.json5
@@ -24,6 +24,16 @@
         'ghcr.io/immich-app/**',
       ],
     },
+    // FileBrowser Quantum は stable と beta のタグを併走させているため、stable のみを追従する
+    {
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        'gtstef/filebrowser',
+      ],
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-stable$',
+    },
     // OCI イメージで参照されるチャートで pinDigest を無効化する
     // https://github.com/renovatebot/renovate/discussions/38038
     {


### PR DESCRIPTION
## 概要

本家 `filebrowser/filebrowser` が 2026-09-01 にアーカイブされ、以降のセキュリティ修正が提供されなくなる。フォークである [gtsteffaniak/filebrowser](https://github.com/gtsteffaniak/filebrowser) (FileBrowser Quantum) の stable 系列へ移行する。

Close #10131

### 候補の比較

| 候補 | Stars | Lang / License | 判定 |
| --- | --- | --- | --- |
| **gtsteffaniak/filebrowser** | 7.9k | Go / Apache-2.0 | ◎ 本家フォークで移行コストが最小。proxy 認証・マルチソース・uid 1000・`/health` が現構成に噛み合う |
| copyparty | 46k | Python / MIT | △ 運用モデルが別物 |
| dufs | 10.7k | Rust / Apache-2.0 | △ 機能が最小限 |
| filestash | 14.5k | Go / AGPL-3.0 | △ 用途に対して重量級 |
| sftpgo | 12.4k | Go / AGPL-3.0 | △ SFTP サーバ主体 |

## 変更点

- 設定を `config.json` から `config.yaml` へ移行
- authentik の forward-auth が付与する `X-authentik-username` を用いた proxy 認証に切り替え、アプリ側の独自ログインを廃止
- 公開対象を `/srv` 配下から `/mnt/pool` 配下へ移動
- DB とキャッシュの書き込み先を hostPath (`/data`) に固定
- `/health` を用いた liveness / readiness / startup probe を追加
- Renovate が stable タグのみ追従するよう `packageRules` を追加

### `/srv` から `/mnt/pool` へ移した理由

Quantum は symlink の解決先がソースのルート外へ出ると `ErrPathEscapesScope` で拒否する ([`indexingFiles.go`](https://github.com/gtsteffaniak/filebrowser/blob/v1.5.3-stable/backend/indexing/indexingFiles.go#L482-L491))。`records_links` 配下のリンクは `/mnt/pool/records/...` を指すため、ルートを `/srv` のままにすると解決できない。`/mnt/pool` をソースのルートにすることで、リンク元とリンク先が同一ルート内に収まる。

コンテナの `/mnt/pool` にはマウントしたディレクトリしか存在しないため、公開範囲は従来と実質同じ (`records` と `records_local` が一覧に現れる点のみ増える)。

### 既知の非互換

- 既存の `filebrowser.db` は Quantum へ移行できないため引き継がない (DB マイグレーションは不要と確認済み)
- 初回起動時は全ソースのインデックス作成が走る。`startupProbe` の猶予を 10 分に設定している
- サムネイル生成が重い場合は `server.disablePreviews` または `userDefaults.preview.*` が抑制の手段になる

## リソースグラフ

```mermaid
flowchart LR
  subgraph cf[Cloudflare]
    dns1["files.starry.blue<br/>(proxied)"]
    dns2["files.gateway.starry.blue"]
  end

  subgraph traefik[Traefik]
    route[IngressRoute route]
    route_gw[IngressRoute route-gateway]
    mw["Middleware<br/>forward-auth-authentik"]
  end

  subgraph authentik[ns: authentik]
    ak[authentik-server]
  end

  subgraph fb[ns: file-browser]
    svc["Service app<br/>:8080"]
    deploy["Deployment deployment<br/>gtstef/filebrowser:1.5.3-stable"]
    cm["ConfigMap app-config<br/>config.yaml"]
  end

  subgraph host[lily hostPath]
    data["/mnt/local/file-browser/data<br/>DB + cache"]
    pool["/mnt/pool/{public,music,<br/>records,records_links,records_local}"]
    cap["/mnt/local/konomitv/data/capture"]
  end

  dns1 --> route
  dns2 --> route_gw
  route --> mw
  route_gw --> mw
  mw -.->|"X-authentik-username"| ak
  route --> svc
  route_gw --> svc
  svc --> deploy
  cm --> deploy
  data --> deploy
  pool -->|"source: pool"| deploy
  cap -->|"source: konomitv-capture"| deploy

  mon["ExternalMonitor https<br/>GET /health"] --> dns1
```

## 検証

実イメージをローカルで起動し、本 PR の `config.yaml` をそのままマウントして検証した。`--read-only` / `-u 1000:1000` は Pod の `securityContext` と同条件。

### 起動

```
[INFO ] cache directory setup successfully: /data/cache
[INFO ] Initializing FileBrowser Quantum (v1.5.3-stable)
[INFO ] Using Config file        : /config/config.yaml
[INFO ] Auth Methods             : [proxy]
[INFO ] Creating new database    : /data/database.db
[INFO ] Sources                  : [konomitv-capture: /capture pool: /mnt/pool]
[INFO ] Running at               : http://0.0.0.0:8080/
```

### API

| 検証 | 結果 |
| --- | --- |
| `GET /health` | `200` |
| ヘッダ無しで `GET /api/resources` | `401` |
| `X-authentik-username: spica` で `GET /api/resources?source=pool` | `200` / `music, public, records, records_links, records_local` |
| 自動作成されたユーザーの権限 | `{"admin": true, "modify": true, "create": true, "delete": true, "download": true, "share": true, "realtime": true}` |
| symlink 配下の一覧 (`/records_links/2026-08`) | `200` / `type: video/mp2t` (実体を解決できている) |
| symlink 経由のダウンロード | `200` / 実体の内容を取得 |
| 書き込み可能なマウントへの作成 (`/music/test.txt`) | `200` / 実ファイルが作成された |
| 読み取り専用マウントへの作成 (`/records/ng.txt`) | `read-only file system` で拒否 |

### 画面

ファイル一覧。authentik のヘッダで `spica` としてログイン済みで、`pool` と `konomitv-capture` の 2 ソースが見えている。

<img width="800" alt="ファイル一覧" src="https://github.com/user-attachments/assets/bd91b3cb-bdd2-4065-91da-668a68277b75" />

`records_links/2026-08` 配下。symlink が動画ファイルとして解決されている。

<img width="800" alt="records_links 配下" src="https://github.com/user-attachments/assets/b6e1b10a-d98c-4297-8e8e-334f05eda888" />

### lint

```
$ go run ./cmd/build-manifests
✅ kustomize build succeeded  root=k8s/apps/file-browser

$ kube-linter lint --config .kube-linter.yaml ./k8s/apps/file-browser
```

kube-linter の指摘は 4 件から 2 件に減少 (`no-readiness-probe` を解消)。残る `default-service-account` と `non-isolated-pod` はリポジトリ全体で共通の既知指摘。

## 未検証

- 実クラスタでの動作。Argo CD の selfHeal によりマージ前の検証は巻き戻るため、画面確認はマージ後に行う
- 実データ (録画 2000 件超) に対する初回インデックスの所要時間と負荷
