### PR TITLE
fix(file-browser): adminUsername を authentik のユーザー名に合わせる

### DIFF
--- a/k8s/apps/file-browser/config/config.yaml
+++ b/k8s/apps/file-browser/config/config.yaml
@@ -1,6 +1,6 @@
 auth:
   # このユーザー名で初回ログインしたときに admin 権限が付与される
-  adminUsername: spica
+  adminUsername: nocturna
   methods:
     password:
       enabled: false


### PR DESCRIPTION
## 概要

#10132 でマージ後に実クラスタで確認したところ、admin 権限が付与されていなかった。

`auth.adminUsername` を `spica` としていたが、authentik が付与する `X-authentik-username` の実際の値は `nocturna` であり一致していなかった。`setupProxyUser` はこの値が一致したときにのみ admin を付与する。

## 証跡

### 修正前 (実クラスタ)

```console
$ kubectl -n file-browser exec deployment/deployment -- \
    wget -qO- --header="X-authentik-username: nocturna" http://localhost:8080/api/users?id=self
{..."username":"nocturna","permissions":{"api":false,"admin":false,"modify":true,"share":true,"realtime":true,"delete":true,"create":true,"download":true}...}
```

`userDefaults.account.permissions` により読み書きはできていたが、`admin` が `false` のままだった。

## 備考

#10132 の検証中に `spica` という不要なユーザーが自動作成されている。本 PR のマージ後、`nocturna` が admin になってから削除する。