### PR TITLE
perf(epgstation): ルール検索のクエリコストを下げる

### DIFF
--- a/k8s/apps/epgstation/kustomization.yaml
+++ b/k8s/apps/epgstation/kustomization.yaml
@@ -29,7 +29,11 @@ helmCharts:
         extraEnvVars:
           - name: TZ
             value: Asia/Tokyo
-        extraFlags: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_520_ci --expire-logs-days=30 --slow-query-log --slow-query-log-file=/dev/stdout --log-output=FILE
+        # innodb-buffer-pool-size: 既定の 128MB では program テーブル (data 107MB + index 5MB) だけで
+        # 使い切ってしまい、ルール検索の全件スキャンのたびに他のページを追い出して読み直していた。
+        # ルールのキーワード検索は LIKE '%…%' なのでインデックスでは救えず、
+        # キャッシュに載せる以外に打つ手が無い。コンテナの memory limit 3Gi の半分を割り当てる。
+        extraFlags: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_520_ci --expire-logs-days=30 --slow-query-log --slow-query-log-file=/dev/stdout --log-output=FILE --innodb-buffer-pool-size=1610612736
         livenessProbe:
           failureThreshold: 5
           periodSeconds: 60
@@ -40,6 +44,7 @@ helmCharts:
 resources:
   - ./../../common/registry-ghcr-io/lily
   - ./resources/cronjob-backup.yaml
+  - ./resources/cronjob-db-maintenance.yaml
   - ./resources/cronjob-restart.yaml
   - ./resources/deployment.yaml
   - ./resources/dns.yaml

--- a/k8s/apps/epgstation/resources/cronjob-db-maintenance.yaml
+++ b/k8s/apps/epgstation/resources/cronjob-db-maintenance.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-maintenance
+
+# EPGStation は TypeORM の固定マイグレーション一覧しか流さない (synchronize: false) ため、
+# 手で足したインデックスが起動時に消えることはない。一方 DBTools のバックアップは
+# JSON でのデータ書き出しであり、そこから復元するとスキーマはマイグレーションで作り直される。
+# つまりインデックスは復元のたびに失われる。マニフェストで追跡し冪等に流し直すため CronJob にしている。
+spec:
+  schedule: "30 5 * * *"
+  timeZone: Asia/Tokyo
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          containers:
+            - name: mariadb
+              # mariadb クライアントを使うだけ。バージョンとレジストリの事情は kustomization.yaml のコメントを参照
+              image: docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0@sha256:888cdaae3cb996c4d28f7916106511de553545929957dd1d35221112df631e19
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  exec mariadb -h mariadb -u epgstation -p"${MARIADB_PASSWORD}" epgstation <<'SQL'
+                  -- ルールの重複回避 (avoidDuplicate) は
+                  --   select P.id from program as P, recorded_history as R
+                  --   where P.shortName = R.name and P.channelId = R.channelId
+                  -- を SELECT 句のサブクエリとして毎回評価する。recorded_history には
+                  -- (channelId, endAt) しか無いため program 全件を駆動表にした結合になっていた。
+                  -- name を先頭に持つインデックスを足すと 1 行参照に落ちる。
+                  -- 上流のマイグレーションと名前が衝突しないよう custom_ を付けている。
+                  CREATE INDEX IF NOT EXISTS custom_idx_rh_name_channelId
+                    ON recorded_history (name(64), channelId);
+
+                  -- program は EPG 更新のたびに全件を消して入れ直すため統計が壊れやすい。
+                  -- Cardinality が全て 1 になると結合順序の判断を誤る。
+                  ANALYZE TABLE program, recorded_history, reserve, recorded;
+                  SQL
+              env:
+                - name: MARIADB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: mariadb-secret
+                      key: mariadb-password
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+          restartPolicy: Never
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+  concurrencyPolicy: Forbid


### PR DESCRIPTION
ルール予約の番組検索が常時 14〜15 秒かかっており、録画開始の遅延とダッシュボードの検索不能につながっている。
そのうち DB 側で改善できる分に対処する。

> [!IMPORTANT]
> これは症状の**二次要因**への対処。主因は EPGStation が Mahiron をチューナー種別 `mirakc` と誤判定し、
> EPG 全件更新 (`updateAll`) が 5 秒おきに多重起動して `DELETE FROM program` が
> 9 本同時にロック待ちしていること。そちらは Mahiron / EPGStation 側のリポジトリで別途対応する。

## 変更内容

### 1. `recorded_history (name(64), channelId)` インデックスの追加

重複回避 (`avoidDuplicate`) が有効なルールでは、`findRule` が SELECT 句で次のサブクエリを評価する。

```sql
select P.id from program as P, recorded_history as R
where P.shortName = R.name and P.channelId = R.channelId and R.endAt <= <now>
```

`recorded_history` には `(channelId, endAt)` しか無く `name` にインデックスが無いため、
`program` 全件を駆動表にして R を 90 行ずつ舐める実行計画になっていた。

**Before**

```
+------+-------------+-------+------+--------------------------------------------------------+------+-------+
| id   | select_type | table | type | key                                                    | rows | Extra |
+------+-------------+-------+------+--------------------------------------------------------+------+-------+
|    1 | SIMPLE      | P     | ALL  | NULL                                                   | 25327|       |
|    1 | SIMPLE      | R     | ref  | idx_recorded_history_channelId_endAt                   |   90 | ...   |
+------+-------------+-------+------+--------------------------------------------------------+------+-------+
```

**After**

```
+------+-------------+-------+------+--------------------------------------------------------+------+-------+
| id   | select_type | table | type | key                                                    | rows | Extra |
+------+-------------+-------+------+--------------------------------------------------------+------+-------+
|    1 | SIMPLE      | P     | ALL  | NULL                                                   | 13754|       |
|    1 | SIMPLE      | R     | ref  | custom_idx_rh_name_channelId                           |    1 | ...   |
+------+-------------+-------+------+--------------------------------------------------------+------+-------+
```

本番を触らずスクラッチ DB に必要列だけ複製して計測した (P=14,186 行, R=3,277 行)。

| | 実行時間 (2 回計測) |
|---|---|
| Before | 1,317 ms / 1,379 ms |
| After | **47 ms / 42 ms** |

本番の実データ (`program` 32,240 行) では Before 側が 4,431 ms だったので、実効差はこれより大きい。

インデックスは `program` ではなく `recorded_history` 側に置いた。
`program` は EPG 更新のたびに 33k 行を入れ直すため、セカンダリインデックスは書き込み経路に直接課税する。
`recorded_history` は 3,338 行 / 1MB の追記専用テーブルで、そのコストがほぼ無い。

### 2. CronJob で冪等に流す

EPGStation は `synchronize: false` + 固定のマイグレーション一覧なので、手で足したインデックスが起動時に消えることはない。
一方 `DBTools` のバックアップは JSON でのデータ書き出しであり、復元するとスキーマはマイグレーションで作り直されて失われる。
マニフェストで追跡するため CronJob にした。オプティマイザ統計の更新も同じジョブでまとめる
(`SHOW INDEX FROM program` の Cardinality が PRIMARY を含め全て 1 になっていた)。

### 3. `innodb-buffer-pool-size` を 128MB → 1.5GiB

ルールのキーワード検索は `halfWidthName LIKE '%…%'` / `REGEXP` で、前方一致でないため B-Tree インデックスでは救えない。
MariaDB には日本語対応の全文検索パーサが無く、イメージに Mroonga も入っていないので全文検索も選べない。
残る手はキャッシュに載せることだけだが、バッファプールが既定の 128MB のままで、
`program` テーブル (data 107MB + index 5MB) だけで使い切っていた。
コンテナの memory limit 3Gi の半分を割り当てる。

## リソースグラフ

```mermaid
flowchart LR
  subgraph ns["Namespace: epgstation"]
    subgraph new["追加"]
      CJM["CronJob<br/>db-maintenance<br/>05:30 JST"]
    end
    CJB["CronJob<br/>backup"]
    CJR["CronJob<br/>restart"]
    DEP["Deployment<br/>app"]
    SEC["OnePasswordItem<br/>mariadb-secret"]
    subgraph mod["変更"]
      STS["StatefulSet<br/>mariadb<br/>+innodb-buffer-pool-size"]
    end
    PVC["PVC<br/>epgstation-mariadb-data"]
  end

  CJM -- "mariadb-password" --> SEC
  CJM -- "CREATE INDEX / ANALYZE TABLE" --> STS
  DEP -- "TCP 3306" --> STS
  CJB -- "JSON dump" --> STS
  CJR -- "rollout restart" --> DEP
  STS --> PVC
  SEC -.-> STS

  style CJM fill:#1f6f3f,stroke:#2ea043,color:#fff
  style STS fill:#7a5c00,stroke:#d29922,color:#fff
```

## 検証

- [x] `go run ./cmd/build-manifests` (exit 0)
- [x] `kube-linter lint --config .kube-linter.yaml` — 新規 CronJob の指摘は既存の `cronjob-backup.yaml` と同一集合 (`default-service-account` / `no-liveness-probe` / `no-readiness-probe` / `non-isolated-pod` / `restart-policy` / `run-as-non-root`)。新規の指摘なし
- [x] `CREATE INDEX IF NOT EXISTS … (name(64), channelId)` の構文と冪等性を MariaDB 12.0.2 の一時 DB で確認 (2 回流してエラーなし)
- [x] インデックスの効果をスクラッチ DB で before/after 計測
- [ ] **CronJob の実行は未検証**。本番へ apply していないため、Pod からの接続・認証・`mariadb` バイナリのパスは机上のまま
- [ ] **本番でのルール検索の before/after は未取得**。上記の主因 (updateAll 多重起動) が続いている間は計測がロック待ちで歪むため、そちらを直した後に取り直す

未検証項目が残っているため Draft にしている。

## 適用時の注意

`extraFlags` の変更は MariaDB の StatefulSet の Pod 再作成を伴う。
このアプリケーションは Argo CD の auto-sync が無効 (`syncPolicy.automated.enabled: false`) なので
マージだけでは適用されないが、**手動 sync のタイミングは録画の隙間を選ぶ必要がある**。

また、現在の updateAll 多重起動が続いている間に MariaDB を落とすと、
巨大なトランザクションのロールバックとクラッシュリカバリを挟んで停止時間が伸びる。
安全な順序は次のとおり。

1. Mahiron 側の修正 (`/api/config/server` の実装) をデプロイ
2. EPGStation を再起動 (チューナー種別の判定キャッシュを飛ばす)
3. `DELETE FROM program` の多重実行が止まったことを確認
4. この PR をマージして手動 sync
