### PR TITLE
chore(epgstation): イメージを updateAll ガード入りへ更新

### DIFF
--- a/k8s/apps/epgstation/resources/cronjob-backup.yaml
+++ b/k8s/apps/epgstation/resources/cronjob-backup.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: backup
-              image: ghcr.io/slashnephy/epgstation-custom-hwaccel:master@sha256:07c7cd373935117099ba3a8f1b3db7cfbce6a978554b73c1bc7b581ce3e652ab
+              image: ghcr.io/slashnephy/epgstation-custom-hwaccel:master@sha256:2c384903695fc1dd88fd5b684f60bf3c3bf9e7a1374da8755708bdbea4994bcf
               command:
                 - node
                 - dist/DBTools.js

--- a/k8s/apps/epgstation/resources/deployment.yaml
+++ b/k8s/apps/epgstation/resources/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/slashnephy/epgstation-custom-hwaccel:master@sha256:07c7cd373935117099ba3a8f1b3db7cfbce6a978554b73c1bc7b581ce3e652ab
+          image: ghcr.io/slashnephy/epgstation-custom-hwaccel:master@sha256:2c384903695fc1dd88fd5b684f60bf3c3bf9e7a1374da8755708bdbea4994bcf
           ports:
             - containerPort: 8888
           volumeMounts:


### PR DESCRIPTION
[SlashNephy/docker-dtv#1037](https://github.com/SlashNephy/docker-dtv/pull/1037) (`updateAll` の多重起動を防ぐパッチ) を含むイメージへ更新する。

## ビルドチェーン

```
docker-dtv 9e7dfa1a  (Merge pull request #1037)
  └─ ghcr.io/slashnephy/epgstation:20260826001859@sha256:8b0ceb8dc375...
       └─ ghcr.io/slashnephy/epgstation-custom-hwaccel:master@sha256:2c384903695f...
```

`src/epgstation-custom-hwaccel/Dockerfile` が `epgstation:20260826001859` の digest を直接 pin しているため、
上記の親子関係はビルドログで確認済み。

## 手動更新の理由

`epgstation-custom-hwaccel` のビルドは `dispatch-update-image-digest: false` で走っており、
`repository-dispatch` のステップが skip される。

```
11 Run peter-evans/repository-dispatch@2895... skipped
```

そのため Update Image Digest ワークフローが発火せず、digest が自動更新されない。今回は手動で更新している。

## 適用時の注意

このマージ自体では適用されない (`epgstation` の Argo CD は auto-sync 無効)。
`#10137` の buffer pool 変更が未 sync のまま残っているため、sync すると MariaDB も同時に再起動する。
現在 `updateAll` の多重起動が継続中で、その最中に MariaDB を落とすと巨大トランザクションの
ロールバックとクラッシュリカバリで停止時間が伸びる。

適用は録画の隙間 (08/26 04:05–07:00) に、次の順序で行う。

1. Deployment だけ先に新イメージへ差し替え
2. `DELETE FROM program` の多重実行が止まり、`updateAll is ... skipped.` がログに出ることを確認
3. その後 Argo CD を sync (MariaDB 再起動 + `db-maintenance` CronJob 作成)
