### PR TITLE
fix(mahiron): recpt1 のゾンビを回収するため PID namespace を共有する

### DIFF
--- a/k8s/apps/mahiron/lily/resources/deployment.yaml
+++ b/k8s/apps/mahiron/lily/resources/deployment.yaml
@@ -152,3 +152,8 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      # Mahiron は tuner を `sh -c "recpt1 ..."` で起動するが、この sh は exec せず fork するため
+      # recpt1 は孫プロセスになる。停止時に Wait されるのは直接の子である sh だけで、
+      # 孤児になった recpt1 はコンテナ内 PID 1 (= mahiron 自身) に reparent されて reap されない。
+      # PID namespace を共有して PID 1 を pause に譲り、pause に孤児を回収させる。
+      shareProcessNamespace: true


### PR DESCRIPTION
## 概要

lily の Mahiron で `[recpt1] <defunct>` が溜まり続ける問題を、`shareProcessNamespace: true` で解消する。

## 原因

1. Mahiron は tuner を `exec.Command("sh", "-c", command)` で起動する（[internal/util/process.go](https://github.com/rokoucha/Mahiron/blob/v5.1.0/internal/util/process.go#L27)）。`tuners.yml` の command は `recpt1 --b25 --strip --device /dev/pxmlt8video1 <channel> - -`。
2. **この `sh` は exec 最適化せず fork する。**稼働中のプロセスは親子で並ぶ。

   ```
   543007  513945  S   sh -c recpt1 --b25 --strip --device /dev/pxmlt8video1 18 - -
   543008  543007  Sl  recpt1 --b25 --strip --device /dev/pxmlt8video1 18 - -
   ```

3. 停止時は `Setpgid: true` + `Kill(-pgid, SIGTERM)` でプロセスグループごと殺すが、`cmd.Wait()` が回収するのは**直接の子である `sh` だけ**。実際 `sh` のゾンビは 1 つも無く、Mahiron 側の Wait は正しく動いている。
4. recpt1 も死ぬが親の `sh` は既に消えているので**コンテナ内 PID 1 に reparent** される。この Pod は `hostPID` を使っていないので、その PID 1 は **mahiron 自身**。

   ```
   /proc/513945/status:  Name: mahiron  NSpid: 513945  1     ← PID 1
   /proc/513970/status:  Name: recpt1   State: Z  PPid: 513945  NSpid: 513970  15
   ```

5. mahiron に孤児を reap する init 機能は無いため `<defunct>` が永久に残る。

つまり **Mahiron のバグではなく、コンテナに init が居ないこと**が原因。

## 影響

tuner の解放 1 回につき必ず 1 個発生する。Pod 起動後のログで `tuner started` 10 / `tuner released` 9 に対しゾンビ 9 個と完全に一致した（約 21 個/時）。放置すると PID 枯渇に至る。

## 検証

busybox の Pod 2 つで孤児の reparent を再現し、`sh -c 'sleep 5 &' ; exec sleep 600` を実行して比較した。

| | コンテナ内 PID 1 | 結果 |
| --- | --- | --- |
| 既定（現状） | `sleep 600`（アプリ自身） | `3 1 Z [sleep]` — **ゾンビが残る** |
| `shareProcessNamespace: true` | `/pause` | **ゾンビ無し**（pause が reap） |

```
$ kubectl exec orphan-off -c app -- ps -o pid,ppid,stat,args
PID   PPID  STAT COMMAND
    1     0 S    sleep 600
    3     1 Z    [sleep]

$ kubectl exec orphan-on -c app -- ps -o pid,ppid,stat,args
PID   PPID  STAT COMMAND
    1     0 S    /pause
    2     0 S    sleep 600
```

マニフェスト側の検証:

```
$ pnpm eslint
（エラー無し）

$ kube-linter lint --config .kube-linter.yaml k8s/apps/mahiron/lily
before=10 after=10（既存の privileged 系のみ。本 PR で増えた指摘は無い）

$ kubectl kustomize --enable-helm k8s/apps/mahiron/lily | kubectl apply --server-side --dry-run=server -f -
deployment.apps/deployment serverside-applied (server dry run)
（round-trip 後も shareProcessNamespace: true が残ることを確認）
```

適用後は EPG gather が毎時 :20 / :50 に走るので、**2 サイクル以上またいでゾンビが 0 のまま**であることを確認する。

## 副作用

- mahiron が PID 1 でなくなる。SIGTERM は引き続きコンテナの主プロセスに届くので graceful shutdown は維持される。
- Pod 内のコンテナ同士がプロセスを見えるようになるが、このPod のコンテナは 1 つだけなので影響は無い。

## リソースグラフ

```mermaid
flowchart TD
    subgraph pod["Pod (mahiron/deployment)"]
        pause["pause (PID 1)<br/>本 PR で追加される reaper"]
        mahiron["mahiron<br/>PID 1 → PID 2 へ"]
        sh["sh -c &quot;recpt1 ...&quot;<br/>mahiron の子"]
        recpt1["recpt1<br/>sh の子 = mahiron の孫"]
    end

    dev["/dev/px4video*<br/>/dev/pxmlt8video*<br/>hostPath"]

    mahiron -->|fork/exec| sh
    sh -->|fork| recpt1
    recpt1 --> dev
    sh -.->|終了時 cmd.Wait で回収| mahiron
    recpt1 -.->|孤児化して reparent| pause

    pause:::added
    classDef added stroke-width:3px
```

変更前は `recpt1 -.->|孤児化して reparent| mahiron` となり、mahiron が reap しないためゾンビが残っていた。

## 残作業

コンテナ側にも init を入れる対応を `StarryBlueSky/docker-dtv` で別途進める。両方入れても競合しない。
