### PR TITLE
chore(mahiron): tini 入りのイメージへ更新する

### DIFF
--- a/k8s/apps/mahiron/lily/resources/deployment.yaml
+++ b/k8s/apps/mahiron/lily/resources/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/starrybluesky/mahiron5-custom:master@sha256:0cf35f4c6a8c6a0a6360fb9620a00bf88ff0a2938ccfec3c957fc3c45ff969b1
+          image: ghcr.io/starrybluesky/mahiron5-custom:master@sha256:9d4c8095961406b47fc7f5fb5a76dfe7b79833c9240744bb51b8792fc5e65eb3
           # イメージ既定の設定ディレクトリは /app/config のため、明示的に上書きする
           args:
             - -config-dir


### PR DESCRIPTION
## 概要

`mahiron5-custom` を tini 入りのビルド成果物へ更新する。

- `sha256:0cf35f4c` → `sha256:9d4c8095`
- ビルド元: [StarryBlueSky/docker-dtv#576](https://github.com/StarryBlueSky/docker-dtv/pull/576)（`5ffecc3`）
- ビルド: [run 32937039644](https://github.com/StarryBlueSky/docker-dtv/actions/runs/32937039644) success
- 同時に付与されたタグ: `master`, `latest`, `20260826151128`, `2026.8.26`, `5ffecc3`

## 目的

Mahiron が `sh -c "recpt1 ..."` で起動した recpt1 は孫プロセスになり、停止時に `cmd.Wait()` で回収されるのは直接の子である `sh` だけ。孤児になった recpt1 は PID 1 に reparent されるが、[上流のベースイメージは `ENTRYPOINT ["mahiron"]` のみで init が無い](https://github.com/rokoucha/Mahiron/blob/main/Dockerfile)ため reap されず `[recpt1] <defunct>` が溜まる。

#10154 の `shareProcessNamespace: true` で PID 1 を pause に譲る対応は既に入っているが、こちらはイメージ単体でも成立させるための対応。`-s`（subreaper）を付けてあるので、PID 1 が pause でも tini が先に孤児を引き取る。両方入れても競合しない。

## 検証

**新イメージの起動と引数の受け渡し**（`args` を差し替えた Pod で確認）:

```
$ kubectl -n mahiron logs mahiron-img-verify
2026/08/26 15:13:51 ERROR failed to load config err="open /nonexistent-dir/channels.yml: no such file or directory"

$ kubectl -n mahiron get pod mahiron-img-verify -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}'
1
```

ENTRYPOINT を tini に差し替えても `args` はそのまま mahiron に届き、終了コードも tini が伝播している。

**tini の reap 動作**（1 世代前のイメージ `sha256:0cf35f4c` での A/B）:

```
tini 無し（現行）        pid=1   ppid=0  state=S  comm=sleep
                        pid=3   ppid=1  state=Z  comm=sleep   ← ゾンビが残る
tini -s 経由            pid=1   ppid=0  state=S  comm=tini
                        pid=119 ppid=1  state=S  comm=sleep   ← ゾンビ無し
```

**マニフェスト**:

```
$ pnpm eslint
（エラー無し）

$ kube-linter lint --config .kube-linter.yaml k8s/apps/mahiron/lily
10 件（既存の privileged 系のみ。本 PR による増加無し）

$ kubectl kustomize --enable-helm k8s/apps/mahiron/lily | kubectl apply --server-side --dry-run=server -f -
deployment.apps/deployment serverside-applied (server dry run)
```

## 未検証

新イメージの PID 1 が実際に tini になっていることは、コンテナを起動したまま `/proc` を覗く必要があるため**デプロイ後に確認する**。`shareProcessNamespace: true` が入っているので PID 1 は pause、tini はその下（`NSpid` が 2）になる想定。

## リソースグラフ

```mermaid
flowchart TD
    subgraph pod["Pod (mahiron/deployment)"]
        pause["pause (PID 1)<br/>#10154 で追加済み"]
        tini["tini -s (PID 2)<br/>本 PR で追加"]
        mahiron["mahiron"]
        sh["sh -c &quot;recpt1 ...&quot;"]
        recpt1["recpt1"]
    end

    dev["/dev/px4video*<br/>/dev/pxmlt8video*<br/>hostPath"]

    tini -->|exec| mahiron
    mahiron -->|fork/exec| sh
    sh -->|fork| recpt1
    recpt1 --> dev
    sh -.->|終了時 cmd.Wait で回収| mahiron
    recpt1 -.->|孤児化して reparent| tini

    tini:::added
    classDef added stroke-width:3px
```

`-s` により tini が subreaper になるため、孤児は pause ではなく tini に引き取られる。
