### PR TITLE
fix(file-browser): SQLite のロック衝突を避けるため Recreate 戦略にする

### DIFF
--- a/k8s/apps/file-browser/resources/deployment.yaml
+++ b/k8s/apps/file-browser/resources/deployment.yaml
@@ -8,6 +8,10 @@ spec:
   selector:
     matchLabels:
       app: default
+  # SQLite の DB を hostPath 上で単一ライターとして開くため、
+  # 新旧 Pod が同時に存在すると "the database is locked" で新 Pod が起動できない
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
## 概要

FileBrowser Quantum は hostPath (`/mnt/local/file-browser/data`) 上の SQLite を単一ライターとして開く。
Deployment が既定の `RollingUpdate` のままだと、新 Pod が起動する時点で旧 Pod がロックを握っているため、新 Pod は `the database is locked` で即座に終了する。新 Pod が Ready にならないのでロールアウトは永久に完了せず、旧 Pod がそのまま配信を続ける。

`strategy.type: Recreate` に変更し、旧 Pod の終了を待ってから新 Pod を作るようにする。`replicas: 1` かつ単一ライターの SQLite なので RollingUpdate に利点はない。

## 現象 (before)

#10134 の ConfigMap 変更で作られた rev27 の Pod が、24 時間で 286 回 CrashLoopBackOff していた。

```console
$ kubectl -n file-browser get pod
NAME                          READY   STATUS             RESTARTS        AGE
deployment-5dff5df4b9-jc9vq   1/1     Running            1               24h
deployment-66498d8564-ns7r6   0/1     CrashLoopBackOff   286 (15s ago)   24h

$ kubectl -n file-browser get rs
NAME                    DESIRED   CURRENT   READY   AGE
deployment-5dff5df4b9   1         1         1       24h   # revision 26
deployment-66498d8564   1         1         0       24h   # revision 27

$ kubectl -n file-browser logs deployment-66498d8564-ns7r6
[INFO ] cache directory setup successfully: /data/cache
 the database is locked, please close all other instances of filebrowser before starting.
```

2 つの ReplicaSet の Pod テンプレートの差分は ConfigMap 名のみで、#10134 の設定変更が 24 時間反映されていなかった。

## 検証

```console
$ kustomize build k8s/apps/file-browser | grep -A2 '^  strategy'
  strategy:
    type: Recreate

$ kubectl apply --dry-run=server -f <(kustomize build k8s/apps/file-browser)
deployment.apps/deployment configured (server dry run)
...
```

マージ後に実クラスタでの収束を確認する。

## リソースグラフ

```mermaid
flowchart LR
  subgraph ns["Namespace: file-browser"]
    deploy["Deployment/deployment<br/>strategy: Recreate"]
    cm["ConfigMap/app-config-*<br/>config.yaml"]
    pod["Pod (replicas: 1)"]
    svc["Service/app :8080"]
  end

  ing["IngressRoute/route<br/>files.starry.blue"] --> svc
  svc --> pod
  deploy -->|creates| pod
  cm -->|mount /config/config.yaml| pod

  db[("hostPath<br/>/mnt/local/file-browser/data<br/>SQLite (単一ライター)")]
  pod --> db

  style deploy stroke-width:3px
```

ConfigMap やイメージが更新されるたびに旧 Pod を先に停止するため、SQLite のロックが競合しなくなる。