### PR TITLE
fix(guacamole): guacd に書き込み可能な HOME を与える

### DIFF
--- a/k8s/apps/guacamole/resources/deployment.yaml
+++ b/k8s/apps/guacamole/resources/deployment.yaml
@@ -76,6 +76,11 @@ spec:
           volumeMounts:
             - name: guacd-tmp
               mountPath: /tmp
+            # FreeRDP は TLS 接続の途中で証明書ストア (HOME/.config/freerdp/certs) を作る。
+            # ignore-cert は検証の可否を変えるだけでストアの初期化は省略しないため、
+            # ここが書けないとハンドシェイクが完了せず RDP 接続に失敗する
+            - name: guacd-home
+              mountPath: /home/guacd
           livenessProbe:
             periodSeconds: 30
             tcpSocket:
@@ -101,6 +106,8 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: guacd-tmp
+          emptyDir: {}
+        - name: guacd-home
           emptyDir: {}
       restartPolicy: Always
       hostname: guacamole


### PR DESCRIPTION
## 問題

[#10179](https://github.com/SlashNephy/infrastructure/pull/10179) の後、`https://remote.starry.blue` にブラウザから接続すると
「ログインに失敗しました。再接続してからもう一度お試しください。」で必ず失敗していた。

## 原因

FreeRDP は TLS 接続の**途中で**証明書ストア (`$HOME/.config/freerdp/certs`) を作成する。
`ignore-cert` は検証の可否を変えるだけで、ストアの初期化を省略しない。

guacd コンテナは `readOnlyRootFilesystem: true` で `/home/guacd` に書けないため、
ハンドシェイクが完了せず RDP 接続に失敗していた。

`/tmp` の emptyDir は与えていたが、FreeRDP が使うのは HOME である。

## 切り分けを誤らせたもの

原因の特定に遠回りしたので、次に同じ症状を見る人のために記録しておく。

- guacd は `RDP server closed/refused connection: Security negotiation failed (wrong security type?)` と報告するが、
  **security パラメータは無関係**。`any` / `tls` / `nla` / `rdp` のいずれでも同じ結果になる
- KRdp 側には `[freerdp_tls_handshake]: BIO_do_handshake failed` → `rdp_server_accept_nego() fail` として現れる。
  サーバ側のエラーに見えるが、中断しているのはクライアント (guacd) である
- guacd の起動時警告
  `FreeRDP initialization may fail: Writability of the current user's home directory ("/home/guacd") could not be determined`
  が唯一の手がかりだった。**この警告は無視してはいけない**
- 生の OpenSSL (Python) や `xfreerdp3` は HOME を必要としない、あるいは書ける環境で動くため成功する。
  これらが通ることは guacd が通る根拠にならない

## 検証

`readOnlyRootFilesystem` を外した guacd と Guacamole を検証用の namespace に立て、
ブラウザから同じ経路で接続したところ、guacd が証明書ストアを作成して接続が成立した。

```console
guacd[3]: DEBUG:	creating directory /home/guacd/.config/freerdp
guacd[3]: DEBUG:	creating directory [/home/guacd/.config/freerdp/certs]
```

本番と同じ `readOnlyRootFilesystem: true` のままでは、この 2 行が出ず接続に失敗する。

マニフェスト:

```console
$ pnpm eslint
(エラーなし)

$ kubectl kustomize k8s/apps/guacamole | grep -c '^kind:'
7

$ kubectl kustomize k8s/apps/guacamole | kubectl apply --server-side --dry-run=server -f - | grep -c serverside-applied
7
```

`kube-linter` の 2 件 (`default-service-account`, `non-isolated-pod`) は既存アプリと同じ baseline で、本 PR で増減しない。

## リソースグラフ

```mermaid
flowchart LR
  guacamole["container: app<br/>guacamole 1.6.0"]
  guacd["container: guacd<br/>guacd 1.6.0 (FreeRDP 2.11.7)"]
  tmp["emptyDir: guacd-tmp<br/>/tmp"]
  home["emptyDir: guacd-home<br/>/home/guacd ← 追加"]
  certs["FreeRDP 証明書ストア<br/>.config/freerdp/certs"]
  krdp["KRdp<br/>192.168.1.3:3389"]

  guacamole -->|127.0.0.1:4822| guacd
  guacd --> tmp
  guacd --> home --> certs
  guacd -->|RDP over TLS| krdp
```

## マージ後に確認すること

ブラウザから `https://remote.starry.blue` を開き、authentik を通り、
Momiji のデスクトップが表示されてマウスとキーボードが効くところまで。
`security` と `resize-method` は疎通後に実挙動を見て絞る。
