### PR TITLE
fix(influxdb): メモリ不足による再起動ループを解消する

### DIFF
--- a/k8s/apps/influxdb/kustomization.yaml
+++ b/k8s/apps/influxdb/kustomization.yaml
@@ -21,12 +21,35 @@ helmCharts:
       auth:
         existingSecret: admin-secret
       influxdb:
-        resourcesPreset: medium
+        # resourcesPreset: medium (memory limit 1536Mi) では 12 GB / 322 shard のデータ量に対して
+        # ページキャッシュが確保できず、cgroup が limit に張り付いて reclaim を繰り返していた。
+        # TSM ファイルの refault が毎秒 8,000 回超に達し HTTP 応答が liveness probe の
+        # timeout (30 秒) を超えるため、2 日で 88 回再起動していた。
+        # ノードには 13 GB の空きがあるので、データ量に見合う limit を明示する。
+        resources:
+          limits:
+            cpu: "2"
+            ephemeral-storage: 2Gi
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            ephemeral-storage: 50Mi
+            memory: 2Gi
         service:
           nodePorts:
             http: 30086
             rpc: 30088
           type: NodePort
+        # 322 shard の open と WAL の再生に最大 340 秒かかり、liveness probe の猶予
+        # (initialDelaySeconds 180 + periodSeconds 45 × failureThreshold 6 = 450 秒) に
+        # 余裕がない。startupProbe で起動完了までは liveness probe を止める。
+        startupProbe:
+          enabled: true
+          failureThreshold: 20
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 30
         updateStrategy:
           type: Recreate # host volume を使っているので RollingUpdate できない
       persistence:


### PR DESCRIPTION
## 事象

lily クラスタの InfluxDB が再起動ループに陥っていた。直近 2 日で 88 回 (21 日累計 113 回) の再起動。

```
$ kubectl -n influxdb describe pod influxdb-7bd9f59694-hb2k7
    Restart Count:  113
    Liveness:       http-get http://:http/ delay=180s timeout=30s period=45s #success=1 #failure=6
Events:
  Warning  Unhealthy  32m (x320 over 2d6h)  kubelet  Liveness probe failed: Get "http://10.0.0.125:8086/": context deadline exceeded
  Warning  Unhealthy  29m (x467 over 2d6h)  kubelet  Readiness probe failed: command timed out
  Normal   Killing    28m (x44 over 2d5h)   kubelet  Container influxdb failed liveness probe, will be restarted
```

## 原因

`resourcesPreset: medium` の memory limit 1536Mi が、実データ量に対して不足していた。

```
$ kubectl -n influxdb exec influxdb-... -- du -sh /bitnami/influxdb/data
12G     /bitnami/influxdb/data      # 322 shard
```

コンテナの cgroup は limit に張り付き、TSM ファイルの page cache が reclaim され続けていた。

```
$ cat .../crio-92514492....scope/memory.current  # limit = 1610612736
1599840256                                        # 99.3%
$ grep -E 'workingset_refault_file|pgsteal ' .../memory.stat
workingset_refault_file 16342436   # 起動後 32 分で 1,634 万回 ≒ 8,500 refault/sec
pgsteal 16774875
$ grep -E 'nr_throttled|throttled_usec' .../cpu.stat
nr_throttled 1422                  # 15,453 period 中 9.2%
throttled_usec 207779480
```

読むたびにディスクから読み直す状態になり、HTTP 応答が liveness probe の timeout (30 秒) を超えて kill される、というループ。ノード再起動 (2 日前) で page cache がコールドになったのを機に顕在化した。

なお、ノードには 13 GB の空きがあり、逼迫していない。

```
$ ssh lily free -h
               total        used        free      shared  buff/cache   available
Mem:            31Gi        17Gi       5.4Gi       450Mi       8.8Gi        13Gi
```

## 変更

- `resourcesPreset: medium` をやめ、データ量に見合う `resources` を明示する (memory limit 1536Mi → 4Gi、CPU limit 750m → 2)
- `startupProbe` を有効にする。322 shard の open と WAL 再生に最大 340 秒 (`op_elapsed=339957.002ms`) かかっており、liveness probe の猶予 (`initialDelaySeconds` 180 + `periodSeconds` 45 × `failureThreshold` 6 = 450 秒) に余裕がないため

### 描画結果の差分

```diff
$ kustomize build --enable-helm k8s/apps/influxdb
-            cpu: 750m
+            cpu: "2"
-            memory: 1536Mi
+            memory: 4Gi
-            memory: 1024Mi
+            memory: 2Gi
+        startupProbe:
+          exec:
+            command: [bash, -c, "... timeout 29s influx --host http://$POD_IP:8086 ping"]
+          failureThreshold: 20
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 30
```

`kubectl apply --dry-run=server` 通過。kube-linter の指摘件数は変更前後とも 2 件 (いずれも本変更と無関係な既存指摘) で増減なし。

## リソースグラフ

```mermaid
flowchart LR
  subgraph ns["namespace: influxdb"]
    deploy["Deployment/influxdb<br/>resources: 4Gi / 2 CPU<br/>startupProbe: enabled"]
    pvc["PVC/influxdb-data<br/>8Gi"]
    svc["Service/influxdb<br/>NodePort 30086"]
    route["IngressRoute/route"]
  end
  node["Node: lily<br/>/mnt/local/influxdb/data<br/>12G"]

  route --> svc --> deploy
  deploy --> pvc --> node

  style deploy stroke:#f96,stroke-width:3px
```

## 未検証事項

ArgoCD の selfHeal によりマージ前の実クラスタ検証は巻き戻るため、**マージ後に再起動が止まることを確認してから Ready にする**。確認基準は以下。

- 1〜2 時間、新規の liveness probe 失敗イベントが出ないこと
- Restart Count が増えないこと
- `workingset_refault_file` の増加が止まること (現状 8,500 回/秒)

`memory.current` は健全な状態でも page cache が limit いっぱいまで広がるため、判定基準にしない。

## フォローアップ (本 PR の対象外)

データは `autogen` (無期限) で増え続けており 12 GB に達している。このままではいずれ 4Gi でも同じ事象が再発する。リテンションポリシーの設定を別途検討したい。
