### PR TITLE
fix(influxdb): 常に失敗する startupProbe を customStartupProbe で置き換える

### DIFF
--- a/k8s/apps/influxdb/kustomization.yaml
+++ b/k8s/apps/influxdb/kustomization.yaml
@@ -21,6 +21,23 @@ helmCharts:
       auth:
         existingSecret: admin-secret
       influxdb:
+        # 322 shard の open と WAL の再生に最大 340 秒かかり、liveness probe の猶予
+        # (initialDelaySeconds 180 + periodSeconds 45 × failureThreshold 6 = 450 秒) に
+        # 余裕がない。startupProbe で起動完了までは liveness probe を止める。
+        #
+        # チャート既定の startupProbe は `influx --host <url> ping` を実行するが、influx CLI は
+        # --host をサブコマンドの後ろにしか取らないため常に失敗する (readinessProbe 側は正しい順序で
+        # 書かれている)。チャートを patch せずに済むよう customStartupProbe で置き換える。
+        # 起動が完了して HTTP listener が上がるまでは接続自体が失敗するので、/health で十分。
+        customStartupProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 30
         # resourcesPreset: medium (memory limit 1536Mi) では 12 GB / 322 shard のデータ量に対して
         # ページキャッシュが確保できず、cgroup が limit に張り付いて reclaim を繰り返していた。
         # TSM ファイルの refault が毎秒 8,000 回超に達し HTTP 応答が liveness probe の
@@ -40,16 +57,6 @@ helmCharts:
             http: 30086
             rpc: 30088
           type: NodePort
-        # 322 shard の open と WAL の再生に最大 340 秒かかり、liveness probe の猶予
-        # (initialDelaySeconds 180 + periodSeconds 45 × failureThreshold 6 = 450 秒) に
-        # 余裕がない。startupProbe で起動完了までは liveness probe を止める。
-        startupProbe:
-          enabled: true
-          failureThreshold: 20
-          initialDelaySeconds: 60
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 30
         updateStrategy:
           type: Recreate # host volume を使っているので RollingUpdate できない
       persistence:


### PR DESCRIPTION
## 事象

#10187 で有効にした startupProbe が常に失敗する。私の変更の不具合。

```
$ kubectl -n influxdb get events --field-selector involvedObject.name=influxdb-76f7949fd8-6vwf4
2026-08-29T09:51:07Z   Unhealthy   Startup probe failed: Incorrect Usage. flag provided but not defined: -host
...
Error: flag provided but not defined: -host
```

## 原因

チャート 6.6.16 の startupProbe テンプレートが引数順を誤っている。influx CLI は `--host` をサブコマンドの後ろにしか取らない。

```console
$ grep -n 'influx.*ping' charts/influxdb-6.6.16/influxdb/templates/deployment.yaml
248:  timeout {{ $startupTimeout }}s influx --host http://$POD_IP:{{ ... }} ping     # startupProbe (誤)
278:  timeout {{ $readinessTimeout }}s influx ping --host http://$POD_IP:{{ ... }}   # readinessProbe (正)
```

readinessProbe 側は正しく書かれているため、これまで表面化していなかった。

このままでは `initialDelaySeconds` 60 + `periodSeconds` 30 × `failureThreshold` 20 = 660 秒で必ずコンテナが kill され、#10187 で解消したはずの再起動ループが別の理由で再発する。

## 変更

チャートを patch せずに済むよう `customStartupProbe` で置き換える。起動が完了して HTTP listener が上がるまでは接続自体が失敗する (`Listening` のログは `Open store (end)` の後に出る) ので、判定は `/health` で足りる。probe の秒数は #10187 のまま据え置き。

### 描画結果の差分

```diff
$ kustomize build --enable-helm k8s/apps/influxdb
         startupProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - |
-              . /opt/bitnami/scripts/libinfluxdb.sh
-              influxdb_env
-              export INFLUX_USERNAME="$INFLUXDB_ADMIN_USER"
-              export INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"
-              timeout 29s influx --host http://$POD_IP:8086 ping
           failureThreshold: 20
+          httpGet:
+            path: /health
+            port: http
           initialDelaySeconds: 60
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 30
```

`kubectl apply --dry-run=server` 通過。eslint (`yml/sort-keys`) 通過。kube-linter の指摘件数は 2 件で #10187 から増減なし。

## リソースグラフ

```mermaid
flowchart LR
  subgraph ns["namespace: influxdb"]
    deploy["Deployment/influxdb<br/>customStartupProbe: GET /health"]
    svc["Service/influxdb<br/>NodePort 30086"]
    pvc["PVC/influxdb-data"]
  end
  node["Node: lily"]

  svc --> deploy --> pvc --> node

  style deploy stroke:#f96,stroke-width:3px
```

## 未検証事項

`/health` が無認証で 200 を返すことは、同期後の実レスポンスで確認する。あわせて #10187 の確認基準 (liveness 失敗が出ないこと・Restart Count が増えないこと) も引き続き見る。