### PR TITLE
docs(influxdb): telegraf バケットのリテンション短縮を記録する

### DIFF
--- a/k8s/apps/influxdb/kustomization.yaml
+++ b/k8s/apps/influxdb/kustomization.yaml
@@ -43,6 +43,16 @@ helmCharts:
         # TSM ファイルの refault が毎秒 8,000 回超に達し HTTP 応答が liveness probe の
         # timeout (30 秒) を超えるため、2 日で 88 回再起動していた。
         # ノードには 13 GB の空きがあるので、データ量に見合う limit を明示する。
+        #
+        # あわせて telegraf バケットのリテンションを 10 年から 90 日へ、shard group duration を
+        # 24h から 7d へ短縮した (2026-08-29)。容量は約 11 GB → 3.6 GB に落ちる見込み。
+        # バケットは Helm でも Terraform でも管理していない (TFC からクラスタ内へ到達できない) ため、
+        # influx CLI で直接適用している。値を変えるときは下記を実行する。
+        #
+        #   kubectl -n influxdb exec deploy/influxdb -- bash -c \
+        #     'export INFLUX_TOKEN=$(cat /opt/bitnami/influxdb/secrets/admin-user-token); \
+        #      influx bucket update --host http://127.0.0.1:8086 -i 9640aa1885903715 \
+        #        --retention 90d --shard-group-duration 168h'
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
#10187 のフォローアップ。

## 背景

容量 12 GB のうち **11 GB が `telegraf` バケット**で、リテンションが 10 年だった。memory limit を 4Gi に上げても、このペースでは再発する。

```console
$ influx bucket list --org primary
ID                 Name             Retention    Shard group duration
d7999d8b27dfd644   _monitoring      168h0m0s     24h0m0s
009c91899e73d813   _tasks           72h0m0s      24h0m0s
bea4a860fbcdab28   primary          720h0m0s     168h0m0s
77aad2b23656cec3   sdr-enthusiasts  87600h0m0s   168h0m0s     # 596 MB
9640aa1885903715   telegraf         87600h0m0s   24h0m0s      # 11 GB
```

シャードの時期別分布から、増加ペースは約 **1.2 GB / 月・30 shard / 月**。

```console
$ # /bitnami/influxdb/data/9640aa1885903715/autogen の shard を mtime で集計
2025-12    1339 MB   31 shards
2026-01    1057 MB   25 shards
2026-02     921 MB   21 shards
2026-03    1884 MB   39 shards
2026-04    1527 MB   28 shards
2026-05    1566 MB   34 shards
2026-07    1032 MB   50 shards
2026-08    1368 MB   50 shards
```

## 変更

`telegraf` バケットのリテンションを 10 年 → **90 日**、shard group duration を 24h → **7d** に変更した。容量は約 11 GB → 3.6 GB、shard は約 270 → 13 になる見込み。

30 秒粒度の Kubernetes メトリクスを 3 か月より前まで遡ることは実務上ないため、90 日で足りる。

shard group duration の 7d は、InfluxDB の推奨表 (リテンション 2 日〜6 か月なら 1d) からの意図的な逸脱。shard ごとに 8 パーティションの tsi インデックスを開くため shard 数そのものが起動時間とメモリの負担になっており、90 shard より 13 shard の方が実態に合う。Grafana のクエリ範囲は長くても 7 日程度で、1 クエリが触る shard は 1〜2 個に収まる。削除の粒度が 7 日単位になり最大 97 日分を保持することになるが、実害はない。

`sdr-enthusiasts` は 596 MB と小さいため据え置き。

### 適用結果

```console
$ influx bucket update -i 9640aa1885903715 --retention 90d --shard-group-duration 168h
ID                 Name       Retention   Shard group duration   Organization ID    Schema Type
9640aa1885903715   telegraf   2160h0m0s   168h0m0s               f2c1111ec198938e   implicit
```

バケットは Helm でも Terraform でも管理していない (TFC からクラスタ内へ到達できない) ため、influx CLI で直接適用している。**本 PR はコード変更を伴わず、再現手順と判断の記録のみ。** `kustomize build` の出力は変化しない。

## リソースグラフ

```mermaid
flowchart LR
  telegraf["telegraf<br/>interval 30s"] -->|write| bucket
  sdr["sdr-enthusiasts"] -->|write| sdrb

  subgraph influx["InfluxDB (lily)"]
    bucket["bucket: telegraf<br/>10y → 90d<br/>shard group 24h → 7d"]
    sdrb["bucket: sdr-enthusiasts<br/>10y (据え置き)"]
  end

  bucket --> pvc["PVC/influxdb-data"]
  sdrb --> pvc

  style bucket stroke:#f96,stroke-width:3px
```

## 未検証事項

リテンションの削除は 30 分間隔で走るため、実際に容量が 3.6 GB 前後まで落ちることは適用後に確認する。適用直後は 278 shard / 10552 MB。