### PR TITLE
perf(konomitv): デバッグログを無効化して CPU 負荷を下げる

### DIFF
--- a/k8s/apps/konomitv/lily/config/config.yaml
+++ b/k8s/apps/konomitv/lily/config/config.yaml
@@ -5,8 +5,8 @@ capture:
 
 general:
   backend: Mirakurun
-  debug: true
-  debug_encoder: true
+  debug: false
+  debug_encoder: false
 
   encoder: QSVEncC
   mirakurun_url: "http://app.mahiron:40772/"


### PR DESCRIPTION
## 概要

KonomiTV の `debug` / `debug_encoder` を無効化します。

## 背景

lily の DTV ドロップ調査の一環です。ドロップは **CPU 負荷と相関** しています。

- drop/h vs load1: Spearman rho **+0.242** (z = +5.3, n = 481 録画)
- 同時録画数とは無相関 (rho +0.048) なので、USB 帯域の競合ではない
- load1 の四分位別 drop/h (中央値): 115.7 → 126.4 → 182.0 → **206.9**

lily は 8 コアに対し load average が常時 10 を超えており、恒常的な過負荷状態です。
KonomiTV は定常的に 0.2〜0.4 コアを消費しています。

`debug: true` の実測での影響:

- EPG 更新のたびに全番組の `Add Program` / `Update Program` / `Delete Program` を 1 行ずつ出力し、1 回の更新に **8.951 秒** かかっている
- 録画中のファイルを継続ポーリングし、`File size changed` を毎回記録している (深夜帯は 6 本同時)

## リソースグラフ

```mermaid
flowchart LR
    subgraph konomitv["namespace: konomitv"]
        CM["ConfigMap<br/>app-config-*<br/>(config.yaml)"]
        DP["Deployment<br/>deployment"]
        PO["Pod<br/>KonomiTV.py"]
    end

    CM -->|volumeMount| DP
    DP -->|manages| PO

    style CM stroke-width:3px
    style DP stroke-dasharray: 5 5
    style PO stroke-dasharray: 5 5
```

太線が今回の変更対象です。kustomize の `configMapGenerator` によりハッシュ付きの名前が
`app-config-4484t5kfdh` → `app-config-gtgc9696hf` に変わるため、Deployment が自動で
ロールアウトされ、Pod が再作成されます。

## 検証

`go run ./cmd/build-manifests` が全ルートで成功しています (rc=0)。

```
time=... level=INFO msg="✅ kustomize build succeeded" root=k8s/apps/konomitv/lily
```

生成される ConfigMap の差分:

```diff
 general:
   backend: Mirakurun
-  debug: true
-  debug_encoder: true
+  debug: false
+  debug_encoder: false
```

## 未検証事項

**CPU 負荷が実際にどれだけ下がるかはマージ後にしか測れません。**
KonomiTV は ArgoCD の selfHeal 配下にあるため、事前に手元で値を変えても巻き戻ります。

またドロップへの効果は、**単独では判定できない**見込みです。
7.1.x 期の GR 日別 drop/h は IQR 139〜181 / min 115 / max 296 と日々のばらつきが ±20% あり、
本変更の期待値 (10〜20%) はその中に埋もれます。他の負荷削減と積み上げたうえで、
1 週間以上を日別分布と比較して評価します。

なお `video.recorded_folders` による録画番組の解析機能は今回触っていません。
機能損失を伴うため、本変更の効果を測ってから判断します。