### PR TITLE
feat(traefik): 全ホスト共通で robots.txt を返す

### DIFF
--- a/k8s/system/traefik/lily/kustomization.yaml
+++ b/k8s/system/traefik/lily/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./resources/middlewares/trust-cloudflare-ips.yaml
   - ./resources/namespace.yaml
   - ./resources/priority-class.yaml
+  - ./resources/robots-txt
   - ./resources/routes/dashboard.yaml
   - ./resources/routes/router.yaml
   - ./resources/tls/certificate.yaml

--- a/k8s/system/traefik/lily/resources/robots-txt/config/nginx.conf
+++ b/k8s/system/traefik/lily/resources/robots-txt/config/nginx.conf
@@ -1,0 +1,35 @@
+# robots.txt のみを返す最小構成。
+worker_processes 1;
+pid /tmp/nginx.pid;
+error_log /dev/stderr warn;
+
+events {
+  worker_connections 128;
+}
+
+http {
+  access_log off;
+
+  # 一時ファイルの既定は /var/cache/nginx 以下だが、書き込み可能な /tmp に寄せる。
+  client_body_temp_path /tmp/client-body;
+  fastcgi_temp_path /tmp/fastcgi;
+  proxy_temp_path /tmp/proxy;
+  scgi_temp_path /tmp/scgi;
+  uwsgi_temp_path /tmp/uwsgi;
+
+  # robots.txt しか返さないため mime.types は読み込まない。
+  charset utf-8;
+  default_type text/plain;
+
+  server {
+    listen 8080;
+
+    location = /robots.txt {
+      alias /srv/robots.txt;
+    }
+
+    location / {
+      return 404;
+    }
+  }
+}

--- a/k8s/system/traefik/lily/resources/robots-txt/config/robots.txt
+++ b/k8s/system/traefik/lily/resources/robots-txt/config/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/k8s/system/traefik/lily/resources/robots-txt/kustomization.yaml
+++ b/k8s/system/traefik/lily/resources/robots-txt/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./resources/deployment.yaml
+  - ./resources/ingress.yaml
+  - ./resources/service.yaml
+
+configMapGenerator:
+  - name: robots-txt-config
+    files:
+      - ./config/nginx.conf
+      - ./config/robots.txt

--- a/k8s/system/traefik/lily/resources/robots-txt/resources/deployment.yaml
+++ b/k8s/system/traefik/lily/resources/robots-txt/resources/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: public.ecr.aws/nginx/nginx-unprivileged:alpine@sha256:aa8c9087d36d93e9d650c5365f883b421e8214aedbad24ade52b844c583358f1
+          image: nginxinc/nginx-unprivileged:1.31.5-trixie@sha256:f4a6f1ea26f4e500265b60b1935f2a5a0bc0cc5da4ca02ec32b2099426612229
           # 公式イメージの ENTRYPOINT は /etc/nginx 以下を書き換えようとして
           # readOnlyRootFilesystem で警告を出すため、nginx を直接起動する。
           command:

--- a/k8s/system/traefik/lily/resources/robots-txt/resources/deployment.yaml
+++ b/k8s/system/traefik/lily/resources/robots-txt/resources/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: robots-txt
+
+spec:
+  replicas: 1
+  # lily は単一ノードのため、複製しても可用性は上がらない。
+  # 更新時に robots.txt が落ちないよう、新しい Pod が Ready になってから旧 Pod を止める。
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: robots-txt
+  template:
+    metadata:
+      labels:
+        app: robots-txt
+    spec:
+      containers:
+        - name: app
+          image: public.ecr.aws/nginx/nginx-unprivileged:alpine@sha256:aa8c9087d36d93e9d650c5365f883b421e8214aedbad24ade52b844c583358f1
+          # 公式イメージの ENTRYPOINT は /etc/nginx 以下を書き換えようとして
+          # readOnlyRootFilesystem で警告を出すため、nginx を直接起動する。
+          command:
+            - nginx
+            - -c
+            - /etc/nginx/custom/nginx.conf
+            - -g
+            - daemon off;
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/custom/nginx.conf
+              readOnly: true
+              subPath: nginx.conf
+            - name: config
+              mountPath: /srv/robots.txt
+              readOnly: true
+              subPath: robots.txt
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            httpGet:
+              path: /robots.txt
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /robots.txt
+              port: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: config
+          configMap:
+            name: robots-txt-config
+        - name: tmp
+          emptyDir: {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault

--- a/k8s/system/traefik/lily/resources/robots-txt/resources/ingress.yaml
+++ b/k8s/system/traefik/lily/resources/robots-txt/resources/ingress.yaml
@@ -1,0 +1,38 @@
+# bot のクロールを抑止するため、全ホスト共通で /robots.txt を返す。
+# アプリ側のルーター (Host(...) のみ) より確実に優先させるため priority を明示する。
+#
+# *.starry.blue と *.gateway.starry.blue は TLSOption が異なり、同一 SNI に
+# 複数の TLSOption が紐づくと適用されるオプションが不定になる。混線を避けるため
+# ルーターを分けている。
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: robots-txt
+
+spec:
+  routes:
+    - kind: Rule
+      match: HostRegexp(`^(.+\.)?starry\.blue$`) && !HostRegexp(`^.+\.gateway\.starry\.blue$`) && Path(`/robots.txt`)
+      priority: 1000
+      services:
+        - name: robots-txt
+          port: http
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: robots-txt-gateway
+
+spec:
+  routes:
+    - kind: Rule
+      match: HostRegexp(`^.+\.gateway\.starry\.blue$`) && Path(`/robots.txt`)
+      priority: 1000
+      services:
+        - name: robots-txt
+          port: http
+
+  tls:
+    options:
+      name: gateway

--- a/k8s/system/traefik/lily/resources/robots-txt/resources/service.yaml
+++ b/k8s/system/traefik/lily/resources/robots-txt/resources/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: robots-txt
+
+spec:
+  selector:
+    app: robots-txt
+  ports:
+    - name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
## 概要

`*.starry.blue` の各ホストに bot のアクセスが多いため、全ホスト共通で `/robots.txt` を返すようにする。

既に websecure エントリポイントの既定 middleware (`ban-robots`) が `X-Robots-Tag: none` を返しているが、これはレスポンスヘッダーであり、クロールされた後にしか効かない。クロール前に抑止するため `/robots.txt` を用意する。

内容は全ホスト一律で全面 Disallow とした。

```
User-agent: *
Disallow: /
```

Traefik には静的なレスポンスボディを返す機能がないため、`robots.txt` のみを配信する nginx を traefik namespace に置き、priority を明示した IngressRoute で全ホストの `/robots.txt` を横取りしている。

なお、robots.txt に従わない bot の遮断は Cloudflare 側で別途対応する予定。

## リソースグラフ

```mermaid
flowchart TD
    subgraph clients[クライアント]
        bot["bot / ブラウザ"]
    end

    subgraph traefik["Namespace: traefik"]
        ep["EntryPoint: websecure<br/>(既定 middleware: security-headers / ban-robots / trust-cloudflare-ips)"]

        subgraph new["本 PR で追加"]
            ir1["IngressRoute: robots-txt<br/>HostRegexp(*.starry.blue)<br/>&& !HostRegexp(*.gateway.starry.blue)<br/>&& Path(/robots.txt)<br/>priority: 1000"]
            ir2["IngressRoute: robots-txt-gateway<br/>HostRegexp(*.gateway.starry.blue)<br/>&& Path(/robots.txt)<br/>priority: 1000"]
            svc["Service: robots-txt<br/>:80 → :8080"]
            deploy["Deployment: robots-txt<br/>nginxinc/nginx-unprivileged:1.31.5-trixie<br/>(readOnlyRootFilesystem)"]
            cm["ConfigMap: robots-txt-config<br/>nginx.conf / robots.txt"]
        end

        tls1["TLSOption: cloudflare<br/>(mTLS 必須)"]
        tls2["TLSOption: gateway"]

        app["各アプリの IngressRoute<br/>Host(...) のみ / priority 既定"]
    end

    bot --> ep
    ep -->|"/robots.txt"| ir1
    ep -->|"/robots.txt"| ir2
    ep -->|"それ以外"| app

    ir1 -.->|既定| tls1
    ir2 -.->|明示| tls2

    ir1 --> svc
    ir2 --> svc
    svc --> deploy
    cm -.->|mount| deploy
```

## 設計上の判断

### IngressRoute を 2 本に分けた理由

`*.starry.blue` は既定の TLSOption (`cloudflare`, `clientAuthType: RequireAndVerifyClientCert`)、`*.gateway.starry.blue` は `gateway` TLSOption を使っており、要求されるクライアント証明書が異なる。

Traefik では同一 SNI に対して異なる TLSOption を持つルーターが複数あると、適用されるオプションが不定になる。1 本の catch-all にすると gateway 系ホストが mTLS を要求し始める恐れがあるため、ルーターを分けて `robots-txt-gateway` 側に `tls.options: gateway` を明示している。

### priority を明示した理由

Traefik の既定の優先度はルール文字列長で決まる。今回のルールは長いため放っておいても勝つが、暗黙の依存にしたくないため `priority: 1000` を明示した。アプリ側のルーター (`Host(...)` のみ) は 26 程度になる。

### ENTRYPOINT を上書きしている理由

公式イメージの `docker-entrypoint.d` が `/etc/nginx` 以下を書き換えようとして `readOnlyRootFilesystem` と衝突し警告を出すため、`nginx` を直接起動している。あわせて一時ファイルのパスを `/tmp` に寄せ、書き込み可能な volume は `emptyDir` の `/tmp` のみとした。

## 検証

### 1. Traefik v3.7.11 + nginx でのエンドツーエンド検証

本 PR と同じルール・同じ nginx 設定を docker 上で再現し、Host ヘッダーを変えて確認した。

```console
$ for h in glance.starry.blue epgstation.starry.blue starry.blue whoami.gateway.starry.blue konomitv.gateway.starry.blue; do ... done
--- Host: glance.starry.blue ---
  GET /robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  GET /           -> 200
--- Host: epgstation.starry.blue ---
  GET /robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  GET /           -> 404
--- Host: starry.blue ---
  GET /robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  GET /           -> 404
--- Host: whoami.gateway.starry.blue ---
  GET /robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  GET /           -> 200
--- Host: konomitv.gateway.starry.blue ---
  GET /robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  GET /           -> 404

--- 対象外ホスト (example.com) ---
  GET /robots.txt -> 404
```

`/robots.txt` のみが横取りされ、それ以外のパスは従来どおりアプリのルーターに流れている (`/` の 404 は検証用バックエンドの応答)。starry.blue 以外のホストには反応しない。

### 2. ルール構文と priority (`/api/rawdata`)

```console
app-example@file
  status=enabled priority=26 err=None
  rule=Host(`glance.starry.blue`)
robots-txt-gateway@file
  status=enabled priority=1000 err=None
  rule=HostRegexp(`^.+\.gateway\.starry\.blue$`) && Path(`/robots.txt`)
robots-txt@file
  status=enabled priority=1000 err=None
  rule=HostRegexp(`^(.+\.)?starry\.blue$`) && !HostRegexp(`^.+\.gateway\.starry\.blue$`) && Path(`/robots.txt`)
```

否定演算子を含むルールが `status=enabled` で読み込まれ、アプリ側 (26) より優先されることを確認した。

### 3. readOnlyRootFilesystem + 非 root での起動 (Kubernetes と同じ起動方法)

```console
$ docker run -d --read-only --tmpfs /tmp --user 101 --entrypoint nginx \
    nginxinc/nginx-unprivileged:1.31.5-trixie@sha256:f4a6f1ea... \
    -c /etc/nginx/custom/nginx.conf -g "daemon off;"
$ curl -sD- http://127.0.0.1:18080/robots.txt
HTTP/1.1 200 OK
Server: nginx/1.31.5
Content-Type: text/plain; charset=utf-8
Content-Length: 26
...

User-agent: *
Disallow: /
$ curl -so /dev/null -w "%{http_code}\n" http://127.0.0.1:18080/
404
$ docker logs robots-txt-verify
(出力なし)
```

### 4. `go run ./cmd/build-manifests`

155 件すべて成功、失敗 0 件。

### 5. kube-linter

```console
$ kube-linter lint --config .kube-linter.yaml ./k8s/system/traefik/lily/resources/robots-txt
      1 check: default-service-account
      1 check: non-isolated-pod
      1 check: restart-policy
```

既存の `whoami` / `custom-error-pages` にも出ている 3 件のみで、それらが抱える `no-liveness-probe` / `no-readiness-probe` / `run-as-non-root` / `privileged-ports` は本 PR では発生していない。

### 6. eslint

```console
$ pnpm exec eslint k8s/system/traefik/lily/resources/robots-txt
(指摘なし)
```

## 未検証項目

実クラスタでの応答確認は Argo CD の selfHeal により事前検証ができないため、マージ後に以下を確認する。

- [ ] `curl https://glance.starry.blue/robots.txt` が 200 / `text/plain` を返すこと
- [ ] `whoami.gateway.starry.blue` が引き続きクライアント証明書なしで応答すること (TLSOption の分離が効いていること)
