### PR TITLE
feat(traefik): 各 IngressRoute に robots.txt のルールを追加する

### DIFF
--- a/k8s/apps/1password-connect/terraform-cloud/resources/ingress.yaml
+++ b/k8s/apps/1password-connect/terraform-cloud/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`op-tfc.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`op-tfc.starry.blue`)
       services:

--- a/k8s/apps/7-days-to-die/resources/ingress.yaml
+++ b/k8s/apps/7-days-to-die/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`7dtd.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`7dtd.starry.blue`)
       services:

--- a/k8s/apps/adguard-home/resources/ingress.yaml
+++ b/k8s/apps/adguard-home/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`dns.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`dns.starry.blue`)
       services:

--- a/k8s/apps/amq-media-proxy/resources/ingress.yaml
+++ b/k8s/apps/amq-media-proxy/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`amq-proxy.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`amq-proxy.starry.blue`)
       priority: 10

--- a/k8s/apps/annict-profile-card/production/resources/ingress.yaml
+++ b/k8s/apps/annict-profile-card/production/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`apps.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`apps.starry.blue`) && PathPrefix(`/annict-profile-card`)
       services:

--- a/k8s/apps/anythingllm/resources/ingress.yaml
+++ b/k8s/apps/anythingllm/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`anythingllm.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`anythingllm.starry.blue`)
       priority: 10

--- a/k8s/apps/archi-steam-farm/resources/ingress.yaml
+++ b/k8s/apps/archi-steam-farm/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`asf.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`asf.starry.blue`)
       priority: 10

--- a/k8s/apps/code-server/resources/ingress.yaml
+++ b/k8s/apps/code-server/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`code.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`code.starry.blue`)
       priority: 10

--- a/k8s/apps/dify/resources/ingress.yaml
+++ b/k8s/apps/dify/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`dify.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`dify.starry.blue`) && (PathPrefix(`/console/api`) || PathPrefix(`/api`) || PathPrefix(`/v1`) || PathPrefix(`/files`))
       services:

--- a/k8s/apps/discord-broadcaster/resources/ingress.yaml
+++ b/k8s/apps/discord-broadcaster/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`discord-broadcaster-api.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`discord-broadcaster-api.starry.blue`)
       services:

--- a/k8s/apps/epgstation/resources/ingress.yaml
+++ b/k8s/apps/epgstation/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`epgstation.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`epgstation.starry.blue`)
       priority: 10
@@ -31,6 +40,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`epgstation-api.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`epgstation-api.starry.blue`) && PathPrefix(`/api`)
       services:

--- a/k8s/apps/file-browser/resources/ingress.yaml
+++ b/k8s/apps/file-browser/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`files.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`files.starry.blue`)
       priority: 10
@@ -31,6 +40,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`files.gateway.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`files.gateway.starry.blue`)
       priority: 10

--- a/k8s/apps/glance/resources/ingress.yaml
+++ b/k8s/apps/glance/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`glance.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`glance.starry.blue`)
       services:

--- a/k8s/apps/grafana-alloy/resources/ingress.yaml
+++ b/k8s/apps/grafana-alloy/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`grafana-alloy.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`grafana-alloy.starry.blue`)
       priority: 10

--- a/k8s/apps/grafana/resources/ingress.yaml
+++ b/k8s/apps/grafana/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`grafana.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`grafana.starry.blue`)
       services:

--- a/k8s/apps/guacamole/resources/ingress.yaml
+++ b/k8s/apps/guacamole/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`remote.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`remote.starry.blue`)
       priority: 10

--- a/k8s/apps/headlessx/resources/ingress.yaml
+++ b/k8s/apps/headlessx/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`headlessx.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`headlessx.starry.blue`)
       priority: 10

--- a/k8s/apps/home-assistant/resources/ingress.yaml
+++ b/k8s/apps/home-assistant/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`home.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`home.starry.blue`)
       priority: 10

--- a/k8s/apps/htpasswd-dashboard/resources/ingress.yaml
+++ b/k8s/apps/htpasswd-dashboard/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`basic.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`basic.starry.blue`)
       priority: 10

--- a/k8s/apps/immich/resources/ingress.yaml
+++ b/k8s/apps/immich/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`photos.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`photos.starry.blue`)
       services:

--- a/k8s/apps/influxdb/resources/ingress.yaml
+++ b/k8s/apps/influxdb/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`influxdb.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`influxdb.starry.blue`)
       priority: 10

--- a/k8s/apps/jupyter/resources/ingress.yaml
+++ b/k8s/apps/jupyter/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`jupyter.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`jupyter.starry.blue`)
       priority: 10

--- a/k8s/apps/keel/resources/ingress.yaml
+++ b/k8s/apps/keel/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`keel.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`keel.starry.blue`)
       services:

--- a/k8s/apps/komga/resources/ingress.yaml
+++ b/k8s/apps/komga/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`komga.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`komga.starry.blue`)
       services:

--- a/k8s/apps/konomitv/lily/resources/ingress.yaml
+++ b/k8s/apps/konomitv/lily/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`konomitv.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`konomitv.starry.blue`)
       priority: 10
@@ -62,6 +71,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`konomitv.gateway.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`konomitv.gateway.starry.blue`)
       priority: 10

--- a/k8s/apps/kubeclarity/resources/ingress.yaml
+++ b/k8s/apps/kubeclarity/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`kubeclarity.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`kubeclarity.starry.blue`)
       priority: 10

--- a/k8s/apps/kubernetes-dashboard/resources/ingress.yaml
+++ b/k8s/apps/kubernetes-dashboard/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`k8s.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`k8s.starry.blue`)
       priority: 10

--- a/k8s/apps/librechat/resources/ingress.yaml
+++ b/k8s/apps/librechat/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`librechat.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`librechat.starry.blue`)
       services:

--- a/k8s/apps/lobe-chat/resources/ingress.yaml
+++ b/k8s/apps/lobe-chat/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`lobe-chat.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`lobe-chat.starry.blue`)
       priority: 10

--- a/k8s/apps/local-ai/resources/ingress.yaml
+++ b/k8s/apps/local-ai/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`gpt.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`gpt.starry.blue`)
       services:

--- a/k8s/apps/mahiron/lily/resources/ingress.yaml
+++ b/k8s/apps/mahiron/lily/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`mahiron.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`mahiron.starry.blue`)
       priority: 10
@@ -31,6 +40,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`mahiron-api.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`mahiron-api.starry.blue`) && PathPrefix(`/api`)
       services:

--- a/k8s/apps/minecraft/force_1.12.2/resources/ingress.yaml
+++ b/k8s/apps/minecraft/force_1.12.2/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`mc.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`mc.starry.blue`)
       services:

--- a/k8s/apps/muni/resources/ingress.yaml
+++ b/k8s/apps/muni/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`vj-api.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`vj-api.starry.blue`)
       services:

--- a/k8s/apps/n8n/resources/ingress.yaml
+++ b/k8s/apps/n8n/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`n8n.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`n8n.starry.blue`)
       services:

--- a/k8s/apps/navidrome/resources/ingress.yaml
+++ b/k8s/apps/navidrome/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`navidrome.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`navidrome.starry.blue`)
       priority: 10
@@ -31,6 +40,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`navidrome.gateway.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`navidrome.gateway.starry.blue`)
       priority: 10

--- a/k8s/apps/obsidian-livesync/resources/ingress.yaml
+++ b/k8s/apps/obsidian-livesync/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`obsidian-sync.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`obsidian-sync.starry.blue`)
       services:

--- a/k8s/apps/open-webui/resources/ingress.yaml
+++ b/k8s/apps/open-webui/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`open-webui.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`open-webui.starry.blue`)
       services:

--- a/k8s/apps/openclaw/resources/ingress.yaml
+++ b/k8s/apps/openclaw/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`openclaw.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`openclaw.starry.blue`)
       priority: 10

--- a/k8s/apps/owncast/resources/ingress.yaml
+++ b/k8s/apps/owncast/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`owncast.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`owncast.starry.blue`)
       services:

--- a/k8s/apps/qdrant/resources/ingress.yaml
+++ b/k8s/apps/qdrant/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`qdrant.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     # REST API (API キー)
     - kind: Rule
       match: Host(`qdrant.starry.blue`)

--- a/k8s/apps/rclone-watch/records/resources/ingress.yaml
+++ b/k8s/apps/rclone-watch/records/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`rclone.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`rclone.starry.blue`) && PathPrefix(`/records`)
       services:

--- a/k8s/apps/rustpad/resources/ingress.yaml
+++ b/k8s/apps/rustpad/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`rustpad.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`rustpad.starry.blue`)
       services:

--- a/k8s/apps/sdr-enthusiasts/resources/ingress.yaml
+++ b/k8s/apps/sdr-enthusiasts/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`1090.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`1090.starry.blue`)
       services:

--- a/k8s/apps/stay-tuned/resources/ingress.yaml
+++ b/k8s/apps/stay-tuned/resources/ingress.yaml
@@ -5,6 +5,24 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`stay-tuned-api.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`stay-tuned-river.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`stay-tuned-api.starry.blue`)
       services:

--- a/k8s/apps/stella/resources/ingress.yaml
+++ b/k8s/apps/stella/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`stella.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`stella.starry.blue`)
       services:

--- a/k8s/apps/tiny-tiny-rss/resources/ingress.yaml
+++ b/k8s/apps/tiny-tiny-rss/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`feed.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`feed.starry.blue`)
       services:

--- a/k8s/apps/tuse/resources/ingress.yaml
+++ b/k8s/apps/tuse/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`search.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`search.starry.blue`)
       priority: 10

--- a/k8s/apps/wolweb/resources/ingress.yaml
+++ b/k8s/apps/wolweb/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`wol.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`wol.starry.blue`)
       priority: 10

--- a/k8s/system/argo-cd/resources/ingress.yaml
+++ b/k8s/system/argo-cd/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`argocd.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`argocd.starry.blue`)
       services:

--- a/k8s/system/authentik/resources/ingress.yaml
+++ b/k8s/system/authentik/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`id.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`id.starry.blue`)
       services:

--- a/k8s/system/cilium/lily/resources/ingress.yaml
+++ b/k8s/system/cilium/lily/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`cilium.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`cilium.starry.blue`)
       priority: 10

--- a/k8s/system/juicefs-csi-driver/resources/ingress.yaml
+++ b/k8s/system/juicefs-csi-driver/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`juicefs.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`juicefs.starry.blue`)
       priority: 10

--- a/k8s/system/traefik/lily/resources/routes/dashboard.yaml
+++ b/k8s/system/traefik/lily/resources/routes/dashboard.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`traefik.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`traefik.starry.blue`)
       priority: 10

--- a/k8s/system/traefik/lily/resources/routes/router.yaml
+++ b/k8s/system/traefik/lily/resources/routes/router.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`router.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`router.starry.blue`)
       priority: 10

--- a/k8s/system/traefik/lily/resources/whoami/resources/ingress.yaml
+++ b/k8s/system/traefik/lily/resources/whoami/resources/ingress.yaml
@@ -5,6 +5,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`whoami.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`whoami.starry.blue`)
       services:
@@ -19,6 +28,15 @@ metadata:
 
 spec:
   routes:
+    # bot のクロールを抑止するため robots.txt を返す。
+    - kind: Rule
+      match: Host(`whoami.gateway.starry.blue`) && Path(`/robots.txt`)
+      priority: 100
+      services:
+        - name: robots-txt
+          namespace: traefik
+          port: http
+
     - kind: Rule
       match: Host(`whoami.gateway.starry.blue`)
       services:


### PR DESCRIPTION
#10280 の上に積む Stacked PR。

traefik ns の `robots-txt` Service を各アプリの IngressRoute から**具体的なホスト名**で参照し、全 62 ホストで `/robots.txt` を返す。

## 方式

`HostRegexp` を使う全ホスト共通ルーター (#10275) は、Traefik がルールからドメインを抽出できず TLSOption を紐付けられないため使えなかった。代わりに各 IngressRoute へ次のルールを追加する。

```yaml
    # bot のクロールを抑止するため robots.txt を返す。
    - kind: Rule
      match: Host(`epgstation.starry.blue`) && Path(`/robots.txt`)
      priority: 100
      services:
        - name: robots-txt
          namespace: traefik
          port: http
```

追加先を IngressRoute のドキュメント単位にすることで、`tls.options` の異なるルート (`epgstation-api.starry.blue` の `gateway` など) にも自動的に正しい TLSOption が適用される。

## 重複ホストの扱い

同じホストを複数のアプリが持つ場合は、ルーターの重複を避けるため 1 箇所にのみ追加した。

| ホスト | 追加先 | 理由 |
| --- | --- | --- |
| `files.starry.blue` | file-browser | 稼働中 (miniserve は未デプロイ) |
| `mahiron-api.starry.blue` | mahiron | 稼働中 (mirakurun-iptv-rewriter は未デプロイ) |
| `photos.starry.blue` | immich | photoprism と両方未デプロイのため暫定 |
| `rclone.starry.blue` | rclone-watch/records | radio と両方未デプロイのため暫定 |
| `apps.starry.blue` | annict-profile-card/production | dev ではなく production 側 |

## リソースグラフ

```mermaid
flowchart TD
    bot["bot / ブラウザ"]

    subgraph traefik["Namespace: traefik"]
        ep["EntryPoint: websecure"]
        svc["Service: robots-txt"]
        deploy["Deployment: robots-txt"]
        cm["ConfigMap: robots-txt-config"]
        tr["IngressRoute: dashboard / router / whoami"]
    end

    subgraph apps["Namespace: 各アプリ"]
        ir["IngressRoute (62 ホスト分)<br/>Host(...) && Path(/robots.txt)<br/>priority: 100"]
        app["各アプリの Service"]
    end

    bot --> ep
    ep -->|"/robots.txt"| ir
    ep -->|"それ以外"| app
    ep -->|"/robots.txt"| tr
    ir -->|"cross namespace"| svc
    tr --> svc
    svc --> deploy
    cm -.->|mount| deploy
```

## 検証

### 1. TLSOption を再現した Traefik での検証

#10275 の検証漏れを踏まえ、今回は**エントリポイントの `tls.options`・mTLS・複数 TLSOption・実際の TLS ハンドシェイク**まで再現した。自己署名 CA でクライアント証明書を発行し、`cloudflare` (mTLS 必須) と `gateway` (mTLS なし) の 2 つの TLSOption を持つ Traefik v3.7.11 に対して確認している。

```console
=== epgstation.starry.blue (cloudflare TLSOption: クライアント証明書あり) ===
  /robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  /           -> 200
=== epgstation.starry.blue (クライアント証明書なし → 拒否されるはず) ===
  /robots.txt -> 000 (OpenSSL SSL_read: tlsv13 alert certificate required)
=== epgstation-api.starry.blue (gateway TLSOption: 証明書なしで可) ===
  /robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  /           -> 200
=== konomitv.gateway.starry.blue (gateway TLSOption) ===
  /robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  /           -> 200
```

`/robots.txt` のみが横取りされ、mTLS の要否もホストごとに従来どおり保たれている。

### 2. 対照実験 (#10275 の HostRegexp 版)

同じ環境で、ルーターを #10275 の HostRegexp 版に差し替えると本番と同じ失敗が再現する。

```console
=== 対照実験: HostRegexp 版 (#10275 と同じ) ===
--- Traefik ログ ---
ERR On EntryPoint "websecure", router "robots-hostregexp@file", with no domains in its rule,
    is configured with a TLS options different than the default one,
    default TLSOptions will be applied for it
WRN No domain found in rule HostRegexp(`^(.+\.)?starry\.blue$`) && ... ,
    the TLS option cloudflare@file cannot be applied
    routerName=websecure-conflicted-robots-hostregexp@file
--- epgstation.starry.blue/robots.txt -> 000

=== 本 PR の Host() 列挙版 ===
  conflicted / No domain found ログ件数: 0
  epgstation.starry.blue/robots.txt -> User-agent: */Disallow: //[200 text/plain; charset=utf-8]
  epgstation.starry.blue/           -> 200
```

### 3. カバレッジと重複

リポジトリ内の全 `Host(...)` を突き合わせ、漏れと重複がないことを確認した。

```console
=== 差分 (既存にあって robots 未設定) ===
(なし)
=== 差分 (robots のみ) ===
(なし)
=== 重複チェック ===
(なし)

robots ルールを追加したホスト数: 62
既存の Host(...) のホスト数:     62
```

### 4. `go run ./cmd/build-manifests`

155 件すべて成功、失敗 0 件。

### 5. kube-linter

```console
本ブランチ: found 1112 lint errors
master:     found 1112 lint errors
```

IngressRoute のみの変更のため増減なし。

### 6. eslint

```console
$ pnpm exec eslint k8s
(指摘なし)
```

## 未検証項目

実クラスタでの確認は Argo CD の selfHeal のためマージ後になる。

- [ ] 主要ホストで `curl https://<ホスト>/robots.txt` が 200 / `text/plain` を返すこと
- [ ] `/` が従来どおりのステータス (302 など) を返すこと
- [ ] Traefik のログに `websecure-conflicted-*` が出ないこと