### PR TITLE
fix(mahiron): lily の Pod を Burstable にして CPU の取り分を確保する

### DIFF
--- a/k8s/apps/mahiron/lily/resources/deployment.yaml
+++ b/k8s/apps/mahiron/lily/resources/deployment.yaml
@@ -65,6 +65,16 @@ spec:
               mountPath: /dev/pxmlt8video6
             - name: dev-pxmlt8video7
               mountPath: /dev/pxmlt8video7
+          # requests を指定せず BestEffort になっていると、cgroup v2 の
+          # kubepods-besteffort.slice は cpu.weight=1 で kubepods-burstable.slice (197) に
+          # 200:1 で劣後する。recpt1 は USB のリングバッファを一定間隔で読み出す必要があるため、
+          # ノードが混んでいる間だけランキュー待ちが伸びてドロップが増えていた。
+          # Burstable に上げて CPU の取り分を確保する。
+          # CFS スロットリングによる 100ms 単位の停止はドロップに直結するため limits は付けない。
+          resources:
+            requests:
+              cpu: "2"
+              memory: 1Gi
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
## 背景

Mahiron (lily) の Deployment には `resources` が一切指定されておらず、QoS が **BestEffort** になっていた。

cgroup v2 では QoS クラスごとにスライスが分かれ、その `cpu.weight` は以下のようになっている (lily 実測)。

```
/sys/fs/cgroup/kubepods.slice                      cpu.weight = 313
  ├ kubepods-burstable.slice                       cpu.weight = 197
  └ kubepods-besteffort.slice                      cpu.weight = 1    ← mahiron はここ
```

CFS の nice はスライド**内**の再配分にしか効かないため、`renice` では是正できない。QoS を上げるしかない。

`recpt1` は USB のリングバッファを一定間隔で読み出す必要がある。ノードが混んでいる間だけランキュー待ちが伸び、読み出しが間に合わずにドロップが増えていた。

## before (2026-09-08 08:58:15〜09:28:15, 1800 秒)

TOKYO MX (GR 16ch) を Mahiron の `/api/channels/GR/16/stream?decode=1` から取得。競合は `nebula/ml` (Burstable, requests 500m / limits 3) が窓を通して **295% CPU** で稼働。load1 は 4〜13。

```
recpt1_cmd=recpt1 --b25 --strip --device /dev/px4video6 16 - -
recpt1_cgroup=/kubepods.slice/kubepods-besteffort.slice/...
pod_cpu_weight=1

RECPT1  run=2249ms   wait=33641ms  slices=42737
MAHIRON run=20907ms  wait=47583ms  slices=203473
```

**recpt1 は実行時間の 15.0 倍をランキュー待ちに費やしている。**

## 変更

`requests` を指定して Burstable に上げる。

**`limits` は付けない。** CFS スロットリングは 100ms 周期の完全停止を生み、I/O ポンプである recpt1 にとってはランキュー待ちより有害なため。`memory` の limit も付けない (ページキャッシュの reclaim スラッシングを避ける)。

## after (2026-09-08 09:45:58〜10:15:58, 1800 秒)

同一チャンネル・同一デバイス (`/dev/px4video6`)・同一の競合 (`nebula/ml` が 296%) で再取得。

```
recpt1_cgroup=/kubepods.slice/kubepods-burstable.slice/...
pod_cpu_weight=79   (cpu.max=max / memory.max=max = スロットリングなし)

RECPT1  run=1905ms  wait=3767ms  slices=38469
```

### 比較

| | before (BestEffort) | after (Burstable) | |
|---|---|---|---|
| recpt1 wait / run | **15.0 倍** | **1.98 倍** | |
| recpt1 スライスあたり待ち | **0.787 ms** | **0.098 ms** | −87% |
| **CC 不連続 (dropCnt 相当)** | **165 件** | **0 件** | **−100%** |
| 欠落パケット数 | 594 | **0** | |
| TEI (errorCnt 相当) | 111 | 24 | |
| 正規化 events / 13.5M packets | 129.13 | **0.00** | |
| packets | 17,250,094 | 17,673,079 | |
| load1 平均 | 10.38 | **13.02** | 窓の条件は after のほうが不利 |
| ml CPU 平均 | 296% | 296% | |

**30 分・1767 万パケットで CC 不連続がゼロ。** しかも after の窓のほうが load1 が 25% 高い。

### 注記

- **mahiron 本体の schedstat は比較に使えない。** `/proc/<pid>/schedstat` はメインスレッドのみを報告するため、マルチスレッドの Go プロセスでは全体像にならない (実際 before の値は `ps` の 38% に対し 1.16% にしかならない)。`recpt1` は単一スレッドなので、こちらの値はプロセス全体を表す。
- **TEI は before / after とも「1 クラスタ」で、どちらもストリーム先頭 (0.0% 地点) にある。** チューニング直後のロック過渡であり、本変更とも RF 条件とも無関係。TEI をレートで見ると 86.87 → 18.33 と改善したように見えるが、実体はどちらも単発イベント 1 回である。

```
qos_before.m2ts: packets=17250094 tei=111 clusters=1
  cluster n= 111 span=    119 pkt  at=  0.0% of stream
qos_after.m2ts:  packets=17673079 tei= 24 clusters=1
  cluster n=  24 span=    846 pkt  at=  0.0% of stream
```

## リソースグラフ

```mermaid
flowchart TD
    root["/sys/fs/cgroup<br/>(root)"]
    root --> sys["system.slice<br/>weight=100<br/>kubelet / crio / telegraf"]
    root --> kp["kubepods.slice<br/>weight=313"]
    kp --> bu["kubepods-burstable.slice<br/>weight=197<br/>nebula/ml, cilium, apiserver, etcd"]
    kp --> be["kubepods-besteffort.slice<br/>weight=1"]

    be -.変更前.-> mh["mahiron/deployment<br/>recpt1 x N"]
    bu ==変更後==> mh

    be --> otel["opentelemetry-collector<br/>otel-agent"]

    style mh fill:#2d6a4f,color:#fff
    style be fill:#7f1d1d,color:#fff
    style bu fill:#1e3a5f,color:#fff
```

Co-Authored-By: Claude Mythos 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
