### PR TITLE
fix(lily): kubeadm の kube-proxy addon を skip する

### DIFF
--- a/k8s/init/lily/kubeadm-config.yaml
+++ b/k8s/init/lily/kubeadm-config.yaml
@@ -27,6 +27,10 @@ kind: InitConfiguration
 nodeRegistration:
   name: lily
   criSocket: unix:///var/run/crio/crio.sock
+# Cilium が kubeProxyReplacement: true でサービスの負荷分散を BPF で担うため、
+# kube-proxy addon は入れない。
+skipPhases:
+  - addon/kube-proxy
 
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -36,3 +40,17 @@ failSwapOn: false
 # イメージを 7 日で GC する。閾値ベースの GC は既定値 (high 85 / low 80) のまま。
 # 片方だけ下げると low > high になって kubelet が起動不能になる
 imageMaximumGCAge: 168h
+
+---
+# kubeadm upgrade apply / upgrade node はどちらも addon フェーズを持ち、
+# その中に kube-proxy サブフェーズがある。skip しないとアップグレードのたびに
+# kube-proxy DaemonSet が復活する。
+#   kubeadm upgrade apply --config k8s/init/lily/kubeadm-config.yaml v1.x.y
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: UpgradeConfiguration
+apply:
+  skipPhases:
+    - addon/kube-proxy
+node:
+  skipPhases:
+    - addon/kube-proxy


### PR DESCRIPTION
## 背景

lily の Cilium は `kubeProxyReplacement: true` で、サービスの負荷分散を BPF が担っている。にもかかわらず kubeadm addon の kube-proxy DaemonSet が残ったままだった。

```console
$ kubectl -n kube-system get ds kube-proxy
NAME         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
kube-proxy   1         1         1       1            1           kubernetes.io/os=linux   610d

$ kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium-dbg status | grep KubeProxy
KubeProxyReplacement:    True   [enp1s0 ... (Direct Routing), tailscale0 ...]
```

Argo CD の管理下にはなく (`argocd.argoproj.io/tracking-id` が付いていない)、マニフェストもこのリポジトリに無い。kubeadm が作ったものである。

## kube-proxy は何も運んでいない

iptables には約 980 本の KUBE- ルールが同期され続けている。

```console
$ kubectl -n kube-system exec ds/cilium -c cilium-agent -- sh -c 'iptables-save | grep -c "KUBE-"; ip6tables-save | grep -c "KUBE-"'
852
128
```

しかしパケットカウンタを見ると、**`KUBE-SVC-*` / `KUBE-SEP-*` のルールは 1 本も match していない** (Pod 起動から 7 日経過時点)。非ゼロなのは素通り用のルールだけである。

```console
$ kubectl -n kube-system exec ds/cilium -c cilium-agent -- sh -c \
    'iptables -t nat -L -n -v | awk "/^Chain KUBE/{c=\$2} /^ *[1-9][0-9]* /{print c, \$0}"'
KUBE-POSTROUTING  1380 84738 RETURN  all  --  *  *  0.0.0.0/0  0.0.0.0/0  mark match ! 0x4000/0x4000
KUBE-SERVICES      548 34696 KUBE-NODEPORTS  all  --  *  *  0.0.0.0/0  0.0.0.0/0  ADDRTYPE match dst-type LOCAL
```

`KUBE-NODEPORTS` に入った 548 パケットも、チェーン内のルールはすべて 0 で素通りしている。filter テーブルの KUBE- ルールも全て 0。

実トラフィックは Cilium 側が受けている。

```console
$ kubectl -n kube-system exec ds/cilium -c cilium-agent -- sh -c 'iptables -t nat -L -n -v | grep cilium-feeder'
   399  50097 CILIUM_PRE_nat   all  --  *  *  0.0.0.0/0  0.0.0.0/0  /* cilium-feeder: CILIUM_PRE_nat */
 21177 1307K CILIUM_OUTPUT_nat all  --  *  *  0.0.0.0/0  0.0.0.0/0  /* cilium-feeder: CILIUM_OUTPUT_nat */
 21177 1307K CILIUM_POST_nat  all  --  *  *  0.0.0.0/0  0.0.0.0/0  /* cilium-feeder: CILIUM_POST_nat */
```

## この PR の変更

`k8s/init/lily/kubeadm-config.yaml` に `addon/kube-proxy` の skip を足す。

- `InitConfiguration.skipPhases` — 再 init したときに作らせない
- `UpgradeConfiguration.apply.skipPhases` / `.node.skipPhases` — `kubeadm upgrade apply` と `kubeadm upgrade node` はどちらも `addon` フェーズを持ち、その中に `kube-proxy` サブフェーズがある。skip しないとアップグレードのたびに復活する

`kubeadm join` には addon フェーズが無いため、`JoinConfiguration` 側の対応は要らない。

## この PR ではクラスタは変わらない

`k8s/init/` は Argo CD の管理外で、クラスタ構築時に手で適用するものである。稼働中の DaemonSet と ConfigMap の削除は、このマージのあとに手で行う。

```bash
kubectl -n kube-system delete ds kube-proxy
kubectl -n kube-system delete cm kube-proxy
```

戻すときは、`skipPhases` を一時的に外して次を実行すれば再作成される。

```bash
kubeadm init phase addon kube-proxy --config k8s/init/lily/kubeadm-config.yaml
```

残る KUBE- ルールは既に何も通していないので、lily の次回再起動で消えるのに任せる。`iptables-save | grep -v KUBE | iptables-restore` は使わない — 同じテーブルに `CILIUM_*` チェーンが同居しており、テーブル全体の復元は危険である。

## 検証

```console
$ pnpm eslint
(指摘なし)

$ python3 -c "import yaml; [print(d.get('kind')) for d in yaml.safe_load_all(open('k8s/init/lily/kubeadm-config.yaml'))]"
ClusterConfiguration
InitConfiguration
KubeletConfiguration
UpgradeConfiguration
```
