### PR TITLE
perf(opentelemetry-collector): filelog の poll_interval を 1s に延ばす

### DIFF
--- a/k8s/system/opentelemetry-collector/kustomization.yaml
+++ b/k8s/system/opentelemetry-collector/kustomization.yaml
@@ -245,6 +245,19 @@ helmCharts:
             # otel-cluster のログも Mackerel に送られてしまうため、両方を除外する。
             exclude:
               - /var/log/pods/opentelemetry-collector_otel-*_*/opentelemetry-collector/*.log
+            # 既定の 200ms では、ログの実流量が 13.7 KiB/s しかないにもかかわらず
+            # otel-agent が CPU 0.26 コアと 27.7 MB/s のアロケーションを消費していた。
+            # 消費のほぼ全量が poll ループ (glob 展開と 380 ファイル分の
+            # フィンガープリント読み) で、処理チェーン側ではない。
+            #
+            # lily と同規模 (355 ファイル / 18.7 rec/s) をローカルで再現して計測した:
+            #   200ms + processors なし : CPU 6.7% / alloc 24.5 MB/s
+            #   200ms + processors フル : CPU 6.7% / alloc 24.4 MB/s
+            #   1s    + processors フル : CPU 1.4% / alloc  5.1 MB/s
+            # 取り込みレコード数はいずれも同一で、取りこぼしはない。
+            #
+            # 代償はログ到達が最大 0.8 秒遅れることだけで、この用途では問題にならない。
+            poll_interval: 1s
           # Alloy から journald ログを OTLP で受け取る。journalctl を実行できない
           # distroless イメージの代わりに、libsystemd を直接呼ぶ Alloy に読み取りを任せる。
           otlp:


### PR DESCRIPTION
## 背景

Mahiron のドロップ調査でノードの定常負荷を測ったところ、`otel-agent` (DaemonSet) が突出していた。

```
kubelet          27%   (system.slice)
otelcol (agent)  25%   (kubepods-besteffort.slice)   ← これ
kube-apiserver    7%
cilium-agent      6%
telegraf          4%
crio              3%
```

ノード全体のログの実流量は **13.7 KiB/s**、レコードレートは 18.9 rec/s しかない。それに対して:

```
CPU                       0.26 コア
アロケーション            27.7 MB/s   (= 1 レコードあたり 1.46 MB)
累計アロケーション        6.30 TB / 2.75 日
heap_alloc                 40 MB      (RSS 173 MB)
```

heap が小さいままアロケーションだけが巨大なので、全量が短命ゴミであり GC を回し続けていた。

## 原因の特定

最初は `transform/severity` の OTTL チェーン (`^.{0,72}?` の有界繰り返しを含む正規表現 4 本) を疑ったが、**これは外れだった**。lily の実ログ 2054 行を採取し、Go (OTTL と同じ RE2) でベンチした結果:

```
corpus: 2054 lines
mismatches: 0 / 2054
current        4.14 us/record
```

チェーン全体で 4.14 マイクロ秒。観測値 (レコードあたりミリ秒オーダー) の説明にならない。

そこで lily と同規模の環境 (355 ログファイル / 142 Pod ディレクトリ / 18.7 rec/s) をローカルの docker で再現し、`otel/opentelemetry-collector-k8s:0.159.0` の同一イメージで条件を振った (各 60 秒計測)。

| arm | poll_interval | max_log_size | processors | CPU | allocation | 取り込み |
|---|---|---|---|---|---|---|
| A | 200ms (既定) | 既定 | なし | 6.7% | 24.5 MB/s | 18.7 rec/s |
| B | 200ms | 64 KiB | なし | 6.7% | 24.6 MB/s | 18.7 rec/s |
| C | **1s** | 既定 | なし | **1.5%** | **5.1 MB/s** | 18.7 rec/s |
| D | **1s** | 64 KiB | なし | **1.2%** | **5.1 MB/s** | 18.7 rec/s |
| E | 200ms | 既定 | **フル** | 6.7% | 24.4 MB/s | 18.7 rec/s |
| F | **1s** | 既定 | **フル** | **1.4%** | **5.1 MB/s** | 18.7 rec/s |

- **A ≈ E** — 処理チェーンを丸ごと足しても増分がない。プロセッサ側は無罪。
- **B ≈ A** — `max_log_size` は無関係。
- **C / F** — `poll_interval` だけで CPU −78%、アロケーション −79%。
- 取り込みレコード数は全条件で同一。**取りこぼしは発生しない。**

lily の実測 27.7 MB/s は arm A の 24.5 MB/s とほぼ一致する。つまり lily のアロケーションもほぼ全量が poll ループ (glob 展開と 380 ファイル分のフィンガープリント読み) である。

## 変更

`poll_interval: 1s` を指定する。代償はログ到達が最大 0.8 秒遅れることだけ。

`max_log_size` は効果がなかったので触らない。正規表現も上記のとおり無罪なので触らない。

## リソースグラフ

```mermaid
flowchart LR
    subgraph node["lily"]
        logs["/var/log/pods<br/>380 files / 142 dirs<br/>13.7 KiB/s"]
        subgraph be["kubepods-besteffort.slice (weight=1)"]
            agent["otel-agent<br/>DaemonSet"]
        end
        alloy["Alloy<br/>journald"]
    end
    mk["Mackerel<br/>otlp-vaxila"]

    logs -->|"file_log<br/>poll 200ms → 1s"| agent
    alloy -->|"otlp/grpc"| agent
    agent -->|"otlphttp"| mk

    style agent fill:#2d6a4f,color:#fff
    style be fill:#7f1d1d,color:#fff
```

## after (lily 実機、2026-09-08)

ArgoCD 同期後、`start_at: end` の追いつきが収まるのを待ってから 180 秒計測。

```
$ kubectl -n opentelemetry-collector get cm otel-agent-... -o jsonpath='{.data.relay}' | grep poll_interval
        poll_interval: 1s
```

| | before | after | |
|---|---|---|---|
| CPU | 25.6 % of a core | **6.0 %** | **−77%** |
| アロケーション | 27.5 MB/s | **5.9 MB/s** | **−79%** |
| file_log 取り込み | 19.0 rec/s | 18.1 rec/s | 同等 |
| RSS | 173 MB | 196 MB | |

ローカル再現での予測 (6.7% → 1.4% = −79%) と相対値で一致した。

ノードの定常負荷 (合計 0.72 コア) のうち **0.20 コアが解放された。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
