### PR TITLE
chore(cronjob): successfulJobsHistoryLimit を 1 に統一する

### DIFF
--- a/k8s/apps/anilist-synchronizer/resources/cronjob.yaml
+++ b/k8s/apps/anilist-synchronizer/resources/cronjob.yaml
@@ -46,3 +46,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/apps/annict2anilist/resources/cronjob.yaml
+++ b/k8s/apps/annict2anilist/resources/cronjob.yaml
@@ -41,3 +41,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/apps/comskip-tvtplay/resources/cronjob.yaml
+++ b/k8s/apps/comskip-tvtplay/resources/cronjob.yaml
@@ -59,3 +59,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/apps/epgstation/resources/cronjob-backup.yaml
+++ b/k8s/apps/epgstation/resources/cronjob-backup.yaml
@@ -54,3 +54,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/apps/epgstation/resources/cronjob-db-maintenance.yaml
+++ b/k8s/apps/epgstation/resources/cronjob-db-maintenance.yaml
@@ -56,3 +56,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/apps/epgstation/resources/cronjob-restart.yaml
+++ b/k8s/apps/epgstation/resources/cronjob-restart.yaml
@@ -35,6 +35,7 @@ spec:
               type: RuntimeDefault
           serviceAccountName: restart
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
 
 ---
 apiVersion: v1

--- a/k8s/apps/m2ts-calendar/resources/cronjob-records-local.yaml
+++ b/k8s/apps/m2ts-calendar/resources/cronjob-records-local.yaml
@@ -65,3 +65,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/apps/m2ts-calendar/resources/cronjob-records.yaml
+++ b/k8s/apps/m2ts-calendar/resources/cronjob-records.yaml
@@ -65,3 +65,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/apps/n8n/resources/cronjob-cleanup-backup.yaml
+++ b/k8s/apps/n8n/resources/cronjob-cleanup-backup.yaml
@@ -44,3 +44,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/apps/stella/resources/cronjob.yaml
+++ b/k8s/apps/stella/resources/cronjob.yaml
@@ -86,3 +86,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/cron/auto-claimer/resources/cronjob.yaml
+++ b/k8s/cron/auto-claimer/resources/cronjob.yaml
@@ -39,3 +39,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/cron/backup-node/resources/cronjob.yaml
+++ b/k8s/cron/backup-node/resources/cronjob.yaml
@@ -40,3 +40,4 @@ spec:
               type: RuntimeDefault
           serviceAccountName: service-account
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/cron/backup-volumes/resources/cronjob.yaml
+++ b/k8s/cron/backup-volumes/resources/cronjob.yaml
@@ -54,3 +54,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/cron/create-tvtest-release/resources/cronjob.yaml
+++ b/k8s/cron/create-tvtest-release/resources/cronjob.yaml
@@ -38,3 +38,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/cron/post-switchbot-metrics/resources/cronjob.yaml
+++ b/k8s/cron/post-switchbot-metrics/resources/cronjob.yaml
@@ -31,3 +31,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/cron/rm-empty-files/resources/cronjob.yaml
+++ b/k8s/cron/rm-empty-files/resources/cronjob.yaml
@@ -37,3 +37,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1

--- a/k8s/system/authentik/resources/cronjob-cleanup-backup.yaml
+++ b/k8s/system/authentik/resources/cronjob-cleanup-backup.yaml
@@ -44,3 +44,4 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1


### PR DESCRIPTION
## 背景

`successfulJobsHistoryLimit` を指定していない CronJob が 17 個あり、既定値の 3 が使われていた。結果として lily に完了済み (Succeeded) の Pod が **44 個**滞留していた (Pod 総数 143 のうち)。

```
$ kubectl get pods -A --field-selector=status.phase=Succeeded --no-headers | wc -l
44
$ kubectl get pods -A --no-headers | wc -l
143
```

滞留した Pod は kubelet の pod / status manager が抱え続け、`/var/log/pods` 配下のログディレクトリも残るため、`otel-agent` の filelog が毎 poll で glob 展開・stat する対象が増える (現在 380 ファイル / 142 ディレクトリ)。

`rclone` の CronJob 5 個は既に `successfulJobsHistoryLimit: 1` を指定しているため、残りをそれに揃える。

## 変更

17 個の CronJob に `successfulJobsHistoryLimit: 1` を追加。

CronJob は 19 個が lily にデプロイされており、履歴上限の合計は 45 → 19 になる。Succeeded Pod は 44 → 十数個まで減る見込み。

## 関連

`poll_interval` の変更 (#10299) と同じレバーの別方向 (片方はポーリング頻度、こちらは対象ファイル数) にあたる。

## リソースグラフ

```mermaid
flowchart TD
    cj["CronJob x 19<br/>successfulJobsHistoryLimit<br/>3 → 1"]
    cj --> job["Job"]
    job --> pod["Pod (Succeeded)<br/>44 個 → 十数個"]
    pod --> kubelet["kubelet<br/>pod / status manager"]
    pod --> logdir["/var/log/pods/<br/>142 dirs / 380 files"]
    logdir --> otel["otel-agent<br/>file_log poll"]

    style cj fill:#2d6a4f,color:#fff
    style pod fill:#7f1d1d,color:#fff
```

## after (lily 実機、2026-09-08)

チャート生成の `pgdumpall` 2 個は #10303 で対応し、19 個すべてが `successfulJobsHistoryLimit: 1` になった。

| | before | after | |
|---|---|---|---|
| Succeeded Pod | 44 | **18** | −59% |
| Pod 総数 | 144 | **116** | −19% |
| `/var/log/pods` ディレクトリ | 146 | **116** | −21% |
| ログファイル | 380 | **357** | −6% |
| 履歴上限の合計 | 45 | **19** | |

### kubelet の CPU には有意な変化なし

滞留 Pod を 26 個減らしたが、kubelet は 27% のまま動かなかった (user 21% / sys 6% で before と同値)。**この変更で kubelet が軽くなるという想定は外れている。** 効果は Pod 一覧とログディレクトリの整理、および filelog の走査対象がわずかに減ることに留まる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
