### PR TITLE
chore(postgresql): backup CronJob の successfulJobsHistoryLimit を 1 にする

### DIFF
--- a/k8s/apps/n8n/kustomization.yaml
+++ b/k8s/apps/n8n/kustomization.yaml
@@ -103,6 +103,7 @@ helmCharts:
           restartPolicy: Never
           # @hourly
           schedule: "20 * * * *"
+          successfulJobsHistoryLimit: 1
           storage:
             existingClaim: n8n-postgresql-backup
           timeZone: Asia/Tokyo

--- a/k8s/apps/n8n/kustomization.yaml
+++ b/k8s/apps/n8n/kustomization.yaml
@@ -103,9 +103,9 @@ helmCharts:
           restartPolicy: Never
           # @hourly
           schedule: "20 * * * *"
-          successfulJobsHistoryLimit: 1
           storage:
             existingClaim: n8n-postgresql-backup
+          successfulJobsHistoryLimit: 1
           timeZone: Asia/Tokyo
         enabled: true
       image:

--- a/k8s/system/authentik/kustomization.yaml
+++ b/k8s/system/authentik/kustomization.yaml
@@ -44,12 +44,12 @@ helmCharts:
             restartPolicy: Never
             # @hourly
             schedule: "30 * * * *"
-            successfulJobsHistoryLimit: 1
             storage:
               volumeClaimTemplates:
                 selector:
                   matchLabels:
                     name: authentik-postgres-backup
+            successfulJobsHistoryLimit: 1
             timeZone: Asia/Tokyo
           enabled: true
         enabled: true

--- a/k8s/system/authentik/kustomization.yaml
+++ b/k8s/system/authentik/kustomization.yaml
@@ -44,6 +44,7 @@ helmCharts:
             restartPolicy: Never
             # @hourly
             schedule: "30 * * * *"
+            successfulJobsHistoryLimit: 1
             storage:
               volumeClaimTemplates:
                 selector:


### PR DESCRIPTION
## 背景

#10300 でリポジトリ内の CronJob マニフェストは揃えたが、postgresql チャートが生成する `pgdumpall` の backup CronJob 2 個だけが既定値の 3 のまま残っていた。

```
$ kubectl get cronjobs -A ... 
cronjobs: 19  limit=1: 17  limit>1: 2  合計: 23
  残: authentik authentik-postgresql-pgdumpall
  残: n8n postgresql-pgdumpall
```

チャートは `backup.cronjob.successfulJobsHistoryLimit` を公開しているため、valuesInline で指定する。

## リソースグラフ

```mermaid
flowchart TD
    n8n["n8n<br/>postgresql-pgdumpall"] --> lim["successfulJobsHistoryLimit<br/>3 → 1"]
    ak["authentik<br/>authentik-postgresql-pgdumpall"] --> lim
    lim --> pod["Succeeded Pod<br/>合計 23 → 19"]

    style lim fill:#2d6a4f,color:#fff
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)