### PR TITLE
fix(authentik): Cloudflare のレンジを trusted_proxy_cidrs に追加する

### DIFF
--- a/k8s/system/authentik/kustomization.yaml
+++ b/k8s/system/authentik/kustomization.yaml
@@ -31,6 +31,17 @@ helmCharts:
         licenseKey: dummy
       global:
         addPrometheusAnnotations: true
+        # authentik Secret は 1Password で管理しており valuesInline.authentik は反映されないため、
+        # 設定は env で直接渡す。
+        env:
+          # authentik 2026.8.1 (goauthentik/authentik#25397) から、クライアント IP は
+          # X-Forwarded-For を右から走査し trusted_proxy_cidrs に含まれない最初の IP を採る。
+          # Traefik はバックエンドへの転送時に自分の peer (= Cloudflare の egress IP) を XFF 末尾へ
+          # 必ず追加するため、Cloudflare のレンジを信頼しないとイベントや通知に出る IP が
+          # Cloudflare のものになる。既定値は上書きされるので既定の CIDR も併せて列挙する。
+          # https://www.cloudflare.com/ips-v4 https://www.cloudflare.com/ips-v6
+          - name: AUTHENTIK_LISTEN__TRUSTED_PROXY_CIDRS
+            value: "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fe80::/10,::1/128,fd00::/104,173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22,2400:cb00::/32,2606:4700::/32,2803:f800::/32,2405:b500::/32,2405:8100::/32,2a06:98c0::/29,2c0f:f248::/32"
       postgresql:
         auth:
           password: dummy


### PR DESCRIPTION
## 概要

authentik のイベントおよび Notification Rule の通知に表示されるクライアント IP が、2026.8.1 から Cloudflare の egress IP になっていた。`AUTHENTIK_LISTEN__TRUSTED_PROXY_CIDRS` に Cloudflare のレンジを追加して解消する。

## 原因

[goauthentik/authentik#25397](https://github.com/goauthentik/authentik/pull/25397)（2026-08-24 マージ = 2026.8.0 のリリース後、2026.8.1 に初収録）で、Rust 実装の `packages/ak-axum/src/extract/client_ip.rs` にクライアント IP の解決処理が入った。

```rust
// rightmost_untrusted_x_forwarded_for
forwarded_ips.iter().rev()
    .find(|ip| ip_addr_trusted(ip).is_none())
    .or_else(|| forwarded_ips.first())
```

X-Forwarded-For を**右から**走査し、`listen.trusted_proxy_cidrs` に含まれない最初の IP を採用する。それ以前（Go proxy / 2026.8.0）は左端採用だった。

Traefik はバックエンドへの転送時に自分の peer を XFF 末尾へ必ず追加するため、authentik には次の形で届く。Cloudflare のレンジを信頼していないと、右端の CF の IP が「最初の untrusted」として採用されてしまう。

```
X-Forwarded-For: <実クライアント>, <Cloudflare egress>
```

これは Traefik 側の `forwardedHeaders.trustedIPs` では解消できない（末尾の付加は転送処理そのもの）。なお `listen.trusted_proxy_cidrs` を参照するのは Rust 側だけで、Python の `ClientIPMiddleware` は Rust 側が書き換えた後の XFF の左端を取るだけである。

## 変更内容

`global.env` で `AUTHENTIK_LISTEN__TRUSTED_PROXY_CIDRS` を渡す。

- authentik Secret は 1Password で管理しており `valuesInline.authentik` は patch で消えるため、`global.env` を使う（`env` は `envFrom` より優先される）
- この設定は**既定値を上書きする**ため、既定の CIDR も併せて列挙する
- クラスタの Pod IPv6 CIDR (`fd00::/104`) も追加する。既定値に含まれておらず、Traefik → authentik のホップが v6 になった場合に直接 peer が untrusted になる
- Helm chart の `authentik.env` ヘルパーはリストを `toString` してしまうため、カンマ区切りの文字列で渡す（Rust 側 config-rs が `list_separator(",")` で分解する）
- Cloudflare のレンジの出典は <https://www.cloudflare.com/ips-v4> と <https://www.cloudflare.com/ips-v6>。Renovate で追随できないため、更新は手動になる

## リソースグラフ

```mermaid
flowchart LR
  client[クライアント]
  cf[Cloudflare]

  subgraph traefik[traefik ns]
    tr[Traefik<br/>websecure entrypoint]
    cw["cloudflarewarp plugin<br/>(trust-cloudflare-ips)"]
  end

  subgraph authentik[authentik ns]
    ir[IngressRoute<br/>id.starry.blue]
    env["global.env<br/>AUTHENTIK_LISTEN__TRUSTED_PROXY_CIDRS<br/>(本 PR で追加)"]
    ak["authentik-server<br/>ak-axum ClientIp extractor"]
    dj[Django ClientIPMiddleware]
    ev[Event / Notification Rule]
  end

  client --> cf --> tr --> cw --> ir --> ak --> dj --> ev
  env -.-> ak

  style env fill:#dcfce7,stroke:#16a34a
```

## 検証

### Before

authentik に届いている X-Forwarded-For（`https://whoami.starry.blue/` の実レスポンス。実クライアント IP は伏せてある）:

```
X-Forwarded-For: <実クライアント>, 2400:cb00:22:1000:4020:84f:ebc2:5ac7
Cf-Connecting-Ip: <実クライアント>
```

`kubectl -n authentik logs authentik-server-... -c server` の `remote` フィールド。`2400:cb00::/32` は Cloudflare のレンジ:

```json
{"host":"id.starry.blue","path":"/health/live/","remote":"2400:cb00:1173:1000:37c1:70e0:6c53:ff84","status":200}
{"host":"konomitv.starry.blue","path":"/outpost.goauthentik.io/auth/traefik","remote":"2400:cb00:763:1000:fb23:84ed:a33:f34f","status":200}
```

### レンダリング結果

```console
$ kustomize build --enable-helm k8s/system/authentik | grep -A1 TRUSTED_PROXY
        - name: AUTHENTIK_LISTEN__TRUSTED_PROXY_CIDRS
          value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fe80::/10,::1/128,fd00::/104,173.245.48.0/20,...,2c0f:f248::/32
```

authentik-server と authentik-worker の両方の Deployment に反映されることを確認した。`pnpm eslint` は指摘なし。

### After

未実施。ArgoCD の selfHeal によりマージ前の適用は巻き戻るため、マージ後に同じ `remote` フィールドで実クライアント IP になることを確認する。

## 未確認事項

- カンマ区切り文字列が Rust 側で正しく `Vec<IpNet>` にデシリアライズされることは、ドキュメントと config-rs の `list_separator` の実装からの判断であり、実際に起動しての確認は未実施。`authentik healthcheck` は不正な値でも成功するため事前検証に使えなかった。マージ後、authentik-server が正常に起動することを併せて確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
